### PR TITLE
ImportError: attempted relative import beyond top-level package

### DIFF
--- a/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
@@ -7,13 +7,15 @@
 
 import json
 import logging
+import sys
+sys.path.append("...")
 
 from pathlib import Path
 
 from tqdm import tqdm
 
-from ...CodeShield.insecure_code_detector import insecure_code_detector
-from ...CodeShield.insecure_code_detector.languages import Language
+from CodeShield.insecure_code_detector import insecure_code_detector
+from CodeShield.insecure_code_detector.languages import Language
 
 from .benchmark import Benchmark
 from .bleu import compute_bleu_score


### PR DESCRIPTION
This file requires update, in python3.12.3 (WSL2) execution as explained in the README.md file provide an error: 'from ...CodeShield.insecure_code_detector import insecure_code_detector - ImportError: attempted relative import beyond top-level package'. In order to access higher level libraries it requires the sys.path.append method, which is implemented in this request.