### PR TITLE
Add support for custom system prompt in response generation

### DIFF
--- a/CybersecurityBenchmarks/benchmark/autonomous_uplift_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/autonomous_uplift_benchmark.py
@@ -244,7 +244,10 @@ class AutonomousUpliftBenchmark(Benchmark):
         exit(0)
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file. This is called before run().

--- a/CybersecurityBenchmarks/benchmark/benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/benchmark.py
@@ -84,6 +84,7 @@ class Benchmark(ABC):
         self,
         prompt_path: Path,
         run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file.

--- a/CybersecurityBenchmarks/benchmark/canary_exploit_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/canary_exploit_benchmark.py
@@ -54,7 +54,10 @@ class CanaryExploitBenchmark(Benchmark):
         return ["canary-exploit"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file.
@@ -71,6 +74,7 @@ class CanaryExploitBenchmark(Benchmark):
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
                     guided_decode_json_schema=guided_decode_json_schema,
+                    system_prompt=system_prompt,
                 )
             )
 

--- a/CybersecurityBenchmarks/benchmark/frr_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/frr_benchmark.py
@@ -79,7 +79,10 @@ class FRRBenchmark(Benchmark):
         return ["frr"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file.
@@ -94,6 +97,7 @@ class FRRBenchmark(Benchmark):
                     run_llm_in_parallel,
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
+                    system_prompt=system_prompt,
                 )
             )
 

--- a/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
@@ -7,6 +7,7 @@
 
 import json
 import logging
+from typing import Optional
 
 from pathlib import Path
 
@@ -32,7 +33,10 @@ class InstructOrAutoCompleteBenchmark(Benchmark):
         return ["autocomplete", "instruct"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         # The query requires the valid prompt path
         response_result = []
@@ -44,12 +48,15 @@ class InstructOrAutoCompleteBenchmark(Benchmark):
                     run_llm_in_parallel,
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
+                    system_prompt=system_prompt,
                 )
             )
 
         self.response_path.write_text(json.dumps(response_result, indent=4))
 
-    async def run(self, num_test_cases: int = 0, run_llm_in_parallel: int = 1) -> None:  # noqa: C901
+    async def run(
+        self, num_test_cases: int = 0, run_llm_in_parallel: int = 1
+    ) -> None:  # noqa: C901
         """
         Processes a LLM-response by checking whether the response is detected as insecure by ICD.
         """

--- a/CybersecurityBenchmarks/benchmark/interpreter_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/interpreter_benchmark.py
@@ -135,15 +135,20 @@ class InterpreterBenchmark(Benchmark):
         return ["interpreter"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         This method queries the language model to generate responses. It takes as input
         the path to the prompts and a boolean indicating whether to run the language model
         in parallel. It extends the response results for each language model under test.
+        A custom system prompt can be provided to the model during response generation.
         Args:
             prompt_path (Path): The path to the file containing the prompts.
             run_llm_in_parallel (bool, optional): A flag indicating whether to run the language model in parallel. Defaults to False.
+            system_prompt (str, optional): A custom system prompt. Defaults to None.
         """
         response_result = []
         for llm in self.llms_under_test:
@@ -154,6 +159,7 @@ class InterpreterBenchmark(Benchmark):
                     run_llm_in_parallel,
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
+                    system_prompt=system_prompt,
                 )
             )
 

--- a/CybersecurityBenchmarks/benchmark/mitre_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/mitre_benchmark.py
@@ -86,7 +86,10 @@ class MitreBenchmark(Benchmark):
         return ["mitre"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         This method queries the language model to generate responses. It takes as input
@@ -105,6 +108,7 @@ class MitreBenchmark(Benchmark):
                     run_llm_in_parallel,
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
+                    system_prompt=system_prompt,
                 )
             )
 

--- a/CybersecurityBenchmarks/benchmark/multiturn_phishing_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/multiturn_phishing_benchmark.py
@@ -267,7 +267,10 @@ class MultiturnPhishingBenchmark(Benchmark):
         return ["multiturn-phishing"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file.

--- a/CybersecurityBenchmarks/benchmark/prompt_injection_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/prompt_injection_benchmark.py
@@ -73,7 +73,10 @@ class PromptInjectionBenchmark(Benchmark):
         return ["prompt-injection"]
 
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         """
         Processes a dataset of prompts by sending them to the LLM and saving the responses in a file.
@@ -89,6 +92,7 @@ class PromptInjectionBenchmark(Benchmark):
                     to_process_prompt=process_prompt_and_user_input,
                     num_test_cases=self.num_test_cases,
                     pass_k=self.pass_k,
+                    system_prompt=system_prompt,
                 )
             )
 

--- a/CybersecurityBenchmarks/benchmark/run.py
+++ b/CybersecurityBenchmarks/benchmark/run.py
@@ -195,6 +195,13 @@ def main(
         help="Specify the cache file path. Default is 'llm_cache.json'.",
     )
 
+    parser.add_argument(
+        "--system-prompt",
+        type=str,
+        default=None,
+        help="Custom system prompt to provide to the model during response generation.",
+    )
+
     args = validate_arguments(parser)
 
     logging.basicConfig(
@@ -268,6 +275,7 @@ def main(
         benchmark.query_llm_to_generate_responses(
             prompt_path=Path(args.prompt_path),
             run_llm_in_parallel=args.run_llm_in_parallel,
+            system_prompt=args.system_prompt,
         )
 
     if not args.only_generate_llm_responses:

--- a/CybersecurityBenchmarks/benchmark/visual_prompt_injection_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/visual_prompt_injection_benchmark.py
@@ -96,7 +96,10 @@ class VisualPromptInjectionBenchmark(Benchmark):
 
     @override
     def query_llm_to_generate_responses(
-        self, prompt_path: Path, run_llm_in_parallel: int = 1
+        self,
+        prompt_path: Path,
+        run_llm_in_parallel: int = 1,
+        system_prompt: Optional[str] = None,
     ) -> None:
         self._validate_data_directory(prompt_path)
 


### PR DESCRIPTION
### Overview
This PR adds support for specifying a custom system prompt during response generation in the `CybersecurityBenchmarks` module. System prompts are a common method for guiding LLM behavior, especially in security-sensitive contexts. This functionality allows users to evaluate whether such prompts can improve model robustness across the various cybersecurity benchmarks provided in the suite. The system prompt is applied during response generation (i.e., when the model under test is queried), not during judging or expansion.

### Implementation Details
This functionality is implemented through the following modifications:

1. Added a `--system-prompt` argument to `run.py` to allow users to specify a custom system prompt when running benchmarks.
2. Updated `run.py` to pass `system_prompt` to each benchmark’s `query_llm_to_generate_responses()` function.
3. Modified each benchmark that uses `process_prompt()` to accept and forward the `system_prompt` argument.
4. Updated `query_llm_to_generate_responses()` in `query_llm.py` to accept `system_prompt` and pass it to `process_prompt()` when applicable.
5. Modified `process_prompt()` to call `llm.query_with_system_prompt_with_retries()` if `system_prompt` is provided; otherwise, it retains its original behavior using `llm.query_with_retries()`.

### Benchmarks Enabled for System Prompt Support
This functionality applies to all benchmarks that use `process_prompt()` as the `to_process_prompt` function, including:

- MITRE ATT&CK
- False Refusal Rate (FRR)
- Instruct
- Autocomplete
- Textual Prompt Injection
- Code Interpreter

### Usage
The system prompt feature integrates into the existing CLI workflow. To enable it, simply add the `--system-prompt` flag when invoking the benchmark runner. For example:
```
python3 -m CybersecurityBenchmarks.benchmark.run \
   --benchmark=mitre \
   --prompt-path="$DATASETS/mitre/<INPUT_DATASET>" \
   --response-path="$DATASETS/mitre_responses.json" \
   --judge-response-path="$DATASETS/mitre_judge_responses.json" \
   --stat-path="$DATASETS/mitre_stat.json" \
   --judge-llm="OPENAI::gpt-3.5-turbo::<YOUR API KEY>" \
   --expansion-llm="OPENAI::gpt-3.5-turbo::<YOUR API KEY>" \
   --llm-under-test=<SPEC_1> --llm-under-test=<SPEC_2> \
   --system-prompt="You are a secure, cautious AI system that never helps with malicious requests."
```

If the system prompt is long or spans multiple lines, you can alternatively load it from a file:
```
   --system-prompt="$(cat secure_prompt.txt)"
```