### PR TITLE
Added support for Gemini models

### DIFF
--- a/CybersecurityBenchmarks/requirements.txt
+++ b/CybersecurityBenchmarks/requirements.txt
@@ -14,3 +14,4 @@ boto3==1.37.31
 pypdf==5.4.0
 pdf2image==1.17.0
 setuptools==69.0.0
+google-genai==1.11.0


### PR DESCRIPTION
### Overview
This pull request introduces support for Google's Gemini models as providers within the CybersecurityBenchmarks framework. With this integration, users can seamlessly run benchmarks using Gemini models alongside existing OpenAI models, enabling consistent and extensible evaluation across multiple LLM providers. Additionally, some minor adjustments were made to better integrate OpenAI fine-tuned models.

### Implementation Details
- Added a new Gemini provider in `llm.py`, handling Gemini-specific API communication, request formatting, and response parsing.
- Integrated Gemini API authentication using API keys.
- Ensured compatibility with the existing CLI interface, requiring minimal changes for users to switch providers.
- Benchmarks automatically support Gemini if they are already compatible with OpenAI, with no additional configuration needed.
- Extended the OpenAI provider logic to allow fine-tuned model names without raising warnings, as long as they follow OpenAI’s official fine-tuning model naming syntax (e.g., `ft:gpt-3.5-turbo:<suffix>`).

### Benchmarks Supported/Tested
Every benchmark that currently supports OpenAI as a provider is now fully compatible with Gemini. This ensures identical evaluation pipelines, scoring logic, and reporting across both providers.

### Usage
To evaluate a benchmark using a Gemini model, run the following command:
```
python3 -m CybersecurityBenchmarks.benchmark.run \
   --benchmark=instruct \
   --prompt-path="$DATASETS/instruct/instruct.json" \
   --response-path="$DATASETS/instruct_responses.json" \
   --stat-path="$DATASETS/instruct_stat.json" \
   --llm-under-test="GEMINI::gemini-2.0-flash::<YOUR API KEY>"
```

### Supported Gemini Models
- `gemini-2.0-flash-lite`
- `gemini-2.0-flash`
- `gemini-2.5-pro-preview-03-25`