### PR TITLE
Use utf-8 encoding by default for multilligual test cases

### DIFF
--- a/CybersecurityBenchmarks/benchmark/autonomous_uplift_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/autonomous_uplift_benchmark.py
@@ -204,7 +204,7 @@ class AutonomousUpliftBenchmark(Benchmark):
         return ["autonomous-uplift"]
 
     def write_responses(self) -> None:
-        self.response_path.write_text(json.dumps(self.response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, self.response_result)
         print(f"Wrote responses to {self.response_path}")
 
     def generator_interrupt_handler(

--- a/CybersecurityBenchmarks/benchmark/autopatching_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/autopatching_benchmark.py
@@ -519,7 +519,7 @@ class AutoPatchingBenchmark(Benchmark):
             reports.append(report_entry)
 
             # Rewrite the file with updated reports
-            reports_path.write_text(json.dumps(reports, indent=4))
+            self.write_json_object_to_path(reports_path, reports)
 
         logging.info(
             f"Added patch generation report for case #{report.crash_id} using {llm_under_test.model}"
@@ -577,7 +577,7 @@ class AutoPatchingBenchmark(Benchmark):
                     AutoPatchingBenchmark.RESPONSES_EXCEPTION_MESSAGE_KEY
                 ] = exception_message
             responses.append(response_entry)
-            self.response_path.write_text(json.dumps(responses, indent=4))
+            self.write_json_object_to_path(self.response_path, responses)
             logging.info(
                 f"Appended response from {llm_under_test.model} for case #{case_id} to {self.response_path}."
             )
@@ -819,10 +819,10 @@ class AutoPatchingBenchmark(Benchmark):
 
         # Write results to files if paths are provided
         if (stat_path := self.stat_path) is not None:
-            stat_path.write_text(json.dumps(evaluation_statistics, indent=4))
+            self.write_json_object_to_path(stat_path, evaluation_statistics)
 
         if (judge_response_path := self.judge_response_path) is not None:
-            judge_response_path.write_text(json.dumps(evaluation_results, indent=4))
+            self.write_json_object_to_path(judge_response_path, evaluation_results)
 
         if should_cleanup_after_eval:
             await ArvoContainer.cleanup_all_containers()

--- a/CybersecurityBenchmarks/benchmark/benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/benchmark.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -120,3 +121,6 @@ class Benchmark(ABC):
         Processes a LLM-response.
         """
         pass
+
+    def write_json_object_to_path(path: Path, data: dict) -> None:
+        path.write_text(json.dumps(data, indent=4, ensure_ascii=False), encoding='utf-8')

--- a/CybersecurityBenchmarks/benchmark/canary_exploit_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/canary_exploit_benchmark.py
@@ -46,7 +46,7 @@ class CanaryExploitBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     async def run(
         self,

--- a/CybersecurityBenchmarks/benchmark/frr_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/frr_benchmark.py
@@ -79,7 +79,7 @@ class FRRBenchmark(Benchmark):
             else:
                 updated_response["judge_response"] = "accept"
             updated_response_result.append(updated_response)
-        self.response_path.write_text(json.dumps(updated_response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, updated_response_result)
 
     async def run(
         self,

--- a/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/instruct_or_autocomplete_benchmark.py
@@ -46,7 +46,7 @@ class InstructOrAutoCompleteBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     async def run(
         self,
@@ -210,6 +210,6 @@ class InstructOrAutoCompleteBenchmark(Benchmark):
                 + f"Over all languages, the average BLEU score is: {bleu_scores_avg:.2f}\n"
             )
 
-        self.response_path.write_text(json.dumps(new_response_dataset, indent=4))
+        self.write_json_object_to_path(self.response_path, new_response_dataset)
         if (stat_path := self.stat_path) is not None:
-            stat_path.write_text(json.dumps(results, indent=4))
+            self.write_json_object_to_path(stat_path, results)

--- a/CybersecurityBenchmarks/benchmark/interpreter_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/interpreter_benchmark.py
@@ -139,7 +139,7 @@ class InterpreterBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     async def run(
         self,
@@ -176,7 +176,7 @@ class InterpreterBenchmark(Benchmark):
         )
         final_result = rearrange_judged_response_for_reasoning(judge_response_result)
         if (judge_path := self.judge_response_path) is not None:
-            judge_path.write_text(json.dumps(final_result, indent=4))
+            self.write_json_object_to_path(judge_path, final_result)
             self.process_results(judge_path)
 
     def extract_boolean_values(self, judge: str, key: str) -> bool:
@@ -266,4 +266,4 @@ class InterpreterBenchmark(Benchmark):
                 )
 
         if (stat_path := self.stat_path) is not None:
-            stat_path.write_text(json.dumps(model_to_category_to_stat, indent=4))
+            self.write_json_object_to_path(stat_path, model_to_category_to_stat)

--- a/CybersecurityBenchmarks/benchmark/mitre_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/mitre_benchmark.py
@@ -96,7 +96,7 @@ class MitreBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     async def run(
         self,
@@ -137,7 +137,7 @@ class MitreBenchmark(Benchmark):
         )
         final_result = rearrange_judged_response_for_reasoning(judge_response_result)
         if (judge_path := self.judge_response_path) is not None:
-            judge_path.write_text(json.dumps(final_result, indent=4))
+            self.write_json_object_to_path(judge_path, final_result)
             self.process_results(judge_path)
 
     def process_results(self, prompt_path: Path) -> None:
@@ -193,7 +193,7 @@ class MitreBenchmark(Benchmark):
             stat_per_model_per_category[response["model"]] = per_category
 
         if (stat_path := self.stat_path) is not None:
-            stat_path.write_text(json.dumps(stat_per_model_per_category, indent=4))
+            self.write_json_object_to_path(stat_path, stat_per_model_per_category)
 
 
 def process_judge_prompt(

--- a/CybersecurityBenchmarks/benchmark/multiturn_phishing_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/multiturn_phishing_benchmark.py
@@ -268,7 +268,7 @@ class MultiturnPhishingBenchmark(Benchmark):
                     pass_k=self.pass_k,
                 )
             )
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     async def run(
         self,
@@ -296,7 +296,7 @@ class MultiturnPhishingBenchmark(Benchmark):
             )
         )
         if (judge_path := self.judge_response_path) is not None:
-            judge_path.write_text(json.dumps(judge_response_result, indent=4))
+            self.write_json_object_to_path(judge_path, judge_response_result)
             self.process_results(judge_path)
         return
 
@@ -364,7 +364,7 @@ class MultiturnPhishingBenchmark(Benchmark):
             "goal_stats": goals_data,
         }
         if (stat_path := self.stat_path) is not None:
-            stat_path.write_text(json.dumps(output_json, indent=4))
+            self.write_json_object_to_path(stat_path, output_json)
         return
 
 

--- a/CybersecurityBenchmarks/benchmark/prompt_injection_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/prompt_injection_benchmark.py
@@ -74,7 +74,7 @@ class PromptInjectionBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     @staticmethod
     def was_injection_successful(response: Dict[str, str]) -> bool:
@@ -109,7 +109,7 @@ class PromptInjectionBenchmark(Benchmark):
             )
         )
         if (judge_path := self.judge_response_path) is not None:
-            judge_path.write_text(json.dumps(judge_response_result, indent=4))
+            self.write_json_object_to_path(judge_path, judge_response_result)
             self.process_results(judge_path)
 
     def process_results(self, prompt_path: Path) -> None:
@@ -205,7 +205,7 @@ class PromptInjectionBenchmark(Benchmark):
             for category, model_stats in output_data.items():
                 for model, stats in model_stats.items():
                     output_by_model[model][category] = stats
-            stat_path.write_text(json.dumps(output_by_model, indent=4))
+            self.write_json_object_to_path(stat_path, output_by_model)
 
 
 def process_judge_prompt(

--- a/CybersecurityBenchmarks/benchmark/query_llm.py
+++ b/CybersecurityBenchmarks/benchmark/query_llm.py
@@ -239,7 +239,7 @@ def query_llm_to_generate_responses(
     if not prompt_path.exists():
         raise ValueError("Please provide valid path for prompts.")
     prompt_dataset: List[Dict[str, Union[int, str]]] = json.loads(
-        prompt_path.read_text()
+        prompt_path.read_text(encoding='utf-8')
     )
     if num_test_cases > 0:
         # Select the test cases distributed evenly across the dataset

--- a/CybersecurityBenchmarks/benchmark/visual_prompt_injection_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/visual_prompt_injection_benchmark.py
@@ -95,7 +95,7 @@ class VisualPromptInjectionBenchmark(Benchmark):
                 )
             )
 
-        self.response_path.write_text(json.dumps(response_result, indent=4))
+        self.write_json_object_to_path(self.response_path, response_result)
 
     @override
     async def run(
@@ -115,9 +115,7 @@ class VisualPromptInjectionBenchmark(Benchmark):
             num_test_cases=num_test_cases,
         )
         if self.judge_response_path is not None:
-            self.judge_response_path.write_text(
-                json.dumps(judge_response_result, indent=4)
-            )
+            self.write_json_object_to_path(self.judge_response_path, judge_response_result)
             self._process_judge_results()
 
     def _process_prompt_for_test_case(
@@ -393,7 +391,7 @@ class VisualPromptInjectionBenchmark(Benchmark):
                 if category != "model"
             }
             output_data["stat_per_model"] = stats["model"]
-            stat_path.write_text(json.dumps(output_data, indent=4))
+            self.write_json_object_to_path(stat_path, output_data)
             # Change the structure of the output data so that it is grouped by model
             output_by_model = {
                 model: {} for model in output_data["stat_per_model"].keys()
@@ -401,4 +399,4 @@ class VisualPromptInjectionBenchmark(Benchmark):
             for category, model_stats in output_data.items():
                 for model, stats in model_stats.items():
                     output_by_model[model][category] = stats
-            stat_path.write_text(json.dumps(output_by_model, indent=4))
+            self.write_json_object_to_path(stat_path, output_by_model)


### PR DESCRIPTION
As the encoding is not designated in json dumps. The judge responses for multilingual test case will be encoded into unicode in the json file, which makes the result quality hard to check. In this PR, the encoding is designated to utf-8 and a common function is written in `benchmark.py` for the sub-classes to use directly.