### PR TITLE
Fix Relative Import Error in demo_alignmentcheck.py

### DIFF
--- a/LlamaFirewall/examples/demo_alignmentcheck.py
+++ b/LlamaFirewall/examples/demo_alignmentcheck.py
@@ -28,12 +28,13 @@ from llamafirewall import (
     UserMessage,
 )
 
-from .logging_setup import init_logger
+# Import the logging_setup module with an absolute import
+from logging_setup import init_logger
 
 # Constants
 ENV_API_KEY: str = "TOGETHER_API_KEY"
 
-logger: logging.Logger = init_logger()
+logger: logging.Logger = init_logger(__name__)
 
 
 def get_sample_traces() -> Dict[str, Trace]:


### PR DESCRIPTION
Hi,
When running `demo_alignmentcheck.py` directly, the script fails with the following import error:
```
ImportError: attempted relative import with no known parent package
```
This occurs because the script is using a relative import (`from .logging_setup import init_logger`), which doesn't work when executing the script directly as a standalone program.

Root Cause
When a Python file is run directly (using `python demo_alignmentcheck.py`), it's treated as the `__main__` module with `__package__` set to `None`. In this context, Python cannot resolve relative imports because it has no package context to determine the relative path from.

Relative imports are designed for modules that are part of an installed package hierarchy, not for directly executed scripts.

Fix
This pull request changes the relative import to an absolute import:
```
# Before:
from .logging_setup import init_logger

# After:
from logging_setup import init_logger
```

Thanks