### PR TITLE
feat: Convert LlamaFirewall to C with D-Bus and Yocto integration

### DIFF
--- a/LlamaFirewall_C/LICENSE
+++ b/LlamaFirewall_C/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LlamaFirewall_C/README.md
+++ b/LlamaFirewall_C/README.md
@@ -1,0 +1,87 @@
+# LlamaFirewall C Implementation
+
+This project is a C-based implementation of the LlamaFirewall, designed to be run as a D-Bus service, primarily for Yocto Linux environments.
+
+## Overview
+
+The LlamaFirewall C service provides content scanning capabilities similar to the original Python LlamaFirewall. It exposes its functionality via a D-Bus interface, allowing other applications on the system to request scans of messages.
+
+Key components:
+-   **Core Logic (`llamafirewall_core.c`):** Handles message processing, scanner orchestration, and decision aggregation.
+-   **Scanners:**
+    -   **RegexScanner (`scanners/regex_scanner.c`):** Performs regex-based pattern matching. Uses the PCRE2 library.
+    -   **PromptGuardScanner (`scanners/prompt_guard_scanner.c`):** Intended for detecting prompt injections and harmful content using ML models. In this C version, it currently **simulates** an Inter-Process Communication (IPC) call to a Python helper script (`promptguard_helper.py`) for the actual model inference. This hybrid approach is used due to the complexity of porting PyTorch/Transformer models directly to C.
+    -   Other scanners can be added following these patterns.
+-   **D-Bus Service (`llamafirewall_dbus_service.c`):** Exposes the firewall via D-Bus (`io.LlamaFirewall` service name) using the `sd-bus` library. The primary method is `ScanMessage`.
+-   **Data Types (`llamafirewall_types.c`):** Defines C equivalents of the Python project's data structures.
+
+## Building
+
+The project uses a `Makefile` located in the `src/` directory.
+
+### Prerequisites
+-   GCC (or compatible C compiler)
+-   Make
+-   `pkg-config`
+-   `pcre2` library (libpcre2-dev or equivalent)
+-   `systemd` library (libsystemd-dev or equivalent, for sd-bus)
+
+### Compilation
+From the `LlamaFirewall_C/src/` directory:
+```bash
+make
+```
+This will produce the `llamafirewall-dbus-service` executable.
+
+To build the unit tests:
+```bash
+make test_TARGET # e.g., make test_regex_scanner, make test_llamafirewall_types
+```
+To run all C unit tests:
+```bash
+make test
+```
+
+## Yocto Integration
+
+A Yocto recipe is provided in `recipes-security/llamafirewall-c/llamafirewall-c_0.1.bb`. This recipe handles:
+-   Building the C executable.
+-   Installing the executable to `/usr/bin/`.
+-   Installing the D-Bus service file (`conf/io.LlamaFirewall.service`) to `/usr/share/dbus-1/system-services/`.
+-   Installing the dummy `promptguard_helper.py` to `/usr/lib/llamafirewall-c/` (path may vary based on Yocto config for `nonarch_base_libdir`).
+-   Managing dependencies (`pcre2`, `systemd`, `python3`).
+
+## D-Bus API
+
+-   **Service:** `io.LlamaFirewall`
+-   **Object Path:** `/io/LlamaFirewall`
+-   **Interface:** `io.LlamaFirewall.Service1`
+
+### Method: `ScanMessage`
+-   **Input Signature:** `ssas` (string `message_content`, string `message_role`, array of structs `trace_history`)
+    -   `message_content`: The text content of the message to scan.
+    -   `message_role`: The role of the message (e.g., "user", "assistant", "tool", "system", "memory").
+    -   `trace_history`: An array of past messages. Each struct is `(ss)`: (string `role`, string `content`). Pass an empty array if no trace.
+-   **Output Signature:** `ssds` (string `decision`, string `reason`, double `score`, string `status`)
+    -   `decision`: "allow", "block", "human_in_the_loop_required", or "error".
+    -   `reason`: Explanation for the decision.
+    -   `score`: Confidence score (0.0 to 1.0).
+    -   `status`: "success" or "error".
+
+### Example `busctl` usage:
+```bash
+busctl call io.LlamaFirewall /io/LlamaFirewall io.LlamaFirewall.Service1 ScanMessage ssas   "Hello, world!"   "user"   0
+```
+
+## Future Development / Refinements
+
+-   **Real IPC for PromptGuardScanner:** Implement the actual IPC mechanism (e.g., using `popen` or sockets) to call the Python `promptguard_helper.py` script. The Python script itself needs to be updated to perform real model inference.
+-   **Implement Other Scanners:** Port or create hybrid wrappers for other scanners from the original LlamaFirewall (CodeShield, PIIDetection, etc.).
+-   **Configuration Management:** Currently, scanner configurations (like which scanners run per role, or PromptGuard thresholds) are largely hardcoded in C. This could be moved to a configuration file.
+-   **Advanced Error Handling:** More detailed error reporting over D-Bus.
+-   **Logging:** Integrate more structured logging (e.g., syslog).
+-   **Comprehensive Unit Tests:** Expand C unit test coverage, especially for `llamafirewall_core.c`.
+-   **Systemd Service Unit:** Provide a systemd `.service` file for managing the `llamafirewall-dbus-service` daemon lifecycle if more control is needed than D-Bus activation provides.
+
+## License
+This project is licensed under the MIT License. See the `LICENSE` file for details.

--- a/LlamaFirewall_C/conf/io.LlamaFirewall.service
+++ b/LlamaFirewall_C/conf/io.LlamaFirewall.service
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=io.LlamaFirewall
+Exec=/usr/bin/llamafirewall-dbus-service
+User=root

--- a/LlamaFirewall_C/recipes-security/llamafirewall-c/llamafirewall-c_0.1.bb
+++ b/LlamaFirewall_C/recipes-security/llamafirewall-c/llamafirewall-c_0.1.bb
@@ -1,0 +1,43 @@
+# LlamaFirewall_C/recipes-security/llamafirewall-c/llamafirewall-c_0.1.bb
+SUMMARY = "LlamaFirewall C D-Bus Service"
+DESCRIPTION = "A C implementation of LlamaFirewall components, exposed via D-Bus."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=24e3e330db6e9998995a200659bc0a7c"
+
+DEPENDS = "pcre2 systemd"
+
+# This recipe assumes the LlamaFirewall_C directory (which contains src/, conf/, LICENSE,
+# and this recipes-security/ folder) is the root of the source for this recipe.
+SRC_URI = "file://./"
+
+# The dummy python script is part of the main source now.
+# It will be found in ${S}/src/promptguard_helper.py after unpacking.
+
+# S is the source directory, which is ${WORKDIR} when SRC_URI is "file://./"
+S = "${WORKDIR}"
+
+# B is the build directory, relative to S. Our Makefile is in S/src.
+B = "${S}/src"
+
+do_compile() {
+    oe_runmake -C ${B} all CC="${CC}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}"
+}
+
+do_install() {
+    # Install the executable
+    install -d ${D}${bindir}
+    install -m 0755 ${B}/llamafirewall-dbus-service ${D}${bindir}/
+
+    # Install the D-Bus service file from S/conf
+    install -d ${D}${datadir}/dbus-1/system-services
+    install -m 0644 ${S}/conf/io.LlamaFirewall.service ${D}${datadir}/dbus-1/system-services/
+
+    # Install the Python helper script from S/src
+    install -d ${D}${nonarch_base_libdir}/llamafirewall-c
+    install -m 0755 ${S}/src/promptguard_helper.py ${D}${nonarch_base_libdir}/llamafirewall-c/
+}
+
+FILES:${PN} += "${datadir}/dbus-1/system-services/io.LlamaFirewall.service"
+FILES:${PN} += "${nonarch_base_libdir}/llamafirewall-c/promptguard_helper.py"
+
+RDEPENDS:${PN} += "pcre2 python3"

--- a/LlamaFirewall_C/src/Makefile
+++ b/LlamaFirewall_C/src/Makefile
@@ -1,0 +1,47 @@
+CC = gcc
+CFLAGS = -Wall -O2 -g
+CFLAGS += $(shell pkg-config --cflags pcre2-8 systemd)
+LDFLAGS = $(shell pkg-config --libs pcre2-8 systemd)
+TARGET_EXEC = llamafirewall-dbus-service
+SRCS = llamafirewall_types.c scanners/regex_scanner.c scanners/prompt_guard_scanner.c llamafirewall_core.c llamafirewall_dbus_service.c
+OBJS = $(SRCS:.c=.o)
+all: $(TARGET_EXEC)
+$(TARGET_EXEC): $(OBJS)
+	$(CC) $(CFLAGS) -o $@ $(OBJS) $(LDFLAGS)
+%.o: %.c
+	$(CC) $(CFLAGS) -c -o $@ $<
+clean:
+	rm -f $(OBJS) $(TARGET_EXEC)
+.PHONY: all clean
+
+# --- Test Targets ---
+TEST_DIR = ../tests
+TEST_HELPERS = $(TEST_DIR)/test_helpers.h
+# Common objects for linking tests if needed (e.g. llamafirewall_types.o)
+COMMON_TEST_OBJS = llamafirewall_types.o
+
+# Test for llamafirewall_types
+TEST_TYPES_SRC = $(TEST_DIR)/test_llamafirewall_types.c
+TEST_TYPES_EXEC = $(TEST_DIR)/test_llamafirewall_types
+$(TEST_TYPES_EXEC): $(TEST_TYPES_SRC) $(COMMON_TEST_OBJS) $(TEST_HELPERS)
+	$(CC) $(CFLAGS) -o $@ $(TEST_TYPES_SRC) $(COMMON_TEST_OBJS) $(LDFLAGS)
+
+# Test for regex_scanner
+TEST_REGEX_SCANNER_SRC = $(TEST_DIR)/test_regex_scanner.c
+TEST_REGEX_SCANNER_OBJS = scanners/regex_scanner.o $(COMMON_TEST_OBJS)
+TEST_REGEX_SCANNER_EXEC = $(TEST_DIR)/test_regex_scanner
+$(TEST_REGEX_SCANNER_EXEC): $(TEST_REGEX_SCANNER_SRC) $(TEST_REGEX_SCANNER_OBJS) $(TEST_HELPERS)
+	$(CC) $(CFLAGS) -o $@ $(TEST_REGEX_SCANNER_SRC) $(TEST_REGEX_SCANNER_OBJS) $(LDFLAGS)
+
+
+# Main test target
+test: $(TEST_TYPES_EXEC) $(TEST_REGEX_SCANNER_EXEC)
+	@echo "Running LlamaFirewall Types tests..."
+	@$(TEST_TYPES_EXEC)
+	@echo "\nRunning RegexScanner tests..."
+	@$(TEST_REGEX_SCANNER_EXEC)
+	@echo "\nC Unit tests finished."
+
+# Add test executables to clean target
+clean:
+	rm -f $(OBJS) $(TARGET_EXEC) $(TEST_TYPES_EXEC) $(TEST_REGEX_SCANNER_EXEC) $(TEST_DIR)/*.o

--- a/LlamaFirewall_C/src/llamafirewall_core.c
+++ b/LlamaFirewall_C/src/llamafirewall_core.c
@@ -1,0 +1,155 @@
+#include "llamafirewall_core.h"
+#include "llamafirewall_types.h" // Already includes stddef.h for size_t
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "scanners/regex_scanner.h" // For regex_scanner_scan, init, cleanup
+#include "scanners/prompt_guard_scanner.h" // For prompt_guard_scanner_scan, init, cleanup
+
+// --- End Placeholder Scanner Implementations ---
+
+
+// Helper to free CScanResult members
+void free_scan_result_members(CScanResult* result) {
+    if (result) {
+        free(result->reason); // free strdup'd string
+        result->reason = NULL;
+    }
+}
+
+int llamafirewall_core_init(LlamaFirewallCore* core) {
+    if (!core) return -1;
+    core->initialized = 0; // Set to 0 initially
+
+    // Initialize Regex Scanner
+    if (regex_scanner_init(&core->regex_scanner_config) != 0) {
+        fprintf(stderr, "Failed to initialize RegexScanner.\n");
+        return -1;
+    }
+
+    // Initialize PromptGuard Scanner
+    // Define a path for the dummy Python script and a block threshold.
+    // These could come from a config file or environment variables in a real app.
+    const char* prompt_guard_script_path = "/opt/llamafirewall/dummy_prompt_guard.py"; // Example path
+    double prompt_guard_threshold = 0.8; // Example threshold
+    if (prompt_guard_scanner_init(&core->prompt_guard_config, prompt_guard_script_path, prompt_guard_threshold) != 0) {
+        fprintf(stderr, "Failed to initialize PromptGuardScanner.\n");
+        regex_scanner_cleanup(&core->regex_scanner_config); // Clean up already initialized scanners
+        return -1;
+    }
+
+    core->initialized = 1; // Set to 1 on successful initialization of all components
+    printf("LlamaFirewallCore initialized successfully.\n");
+    return 0;
+}
+
+void llamafirewall_core_cleanup(LlamaFirewallCore* core) {
+    if (!core) return;
+    regex_scanner_cleanup(&core->regex_scanner_config);
+    prompt_guard_scanner_cleanup(&core->prompt_guard_config);
+    core->initialized = 0;
+    printf("LlamaFirewallCore cleaned up.\n");
+}
+
+CScanResult llamafirewall_scan_message(
+    LlamaFirewallCore* core,
+    const CMessage* input_message,
+    const CTrace* input_trace
+) {
+    if (!core || !core->initialized || !input_message) {
+        return (CScanResult){
+            .decision = SCAN_DECISION_ERROR,
+            .reason = strdup("Core not initialized or invalid input"),
+            .score = 0.0,
+            .status = SCAN_STATUS_ERROR
+        };
+    }
+
+    printf("Scanning message for role: %s\n", c_role_to_string(input_message->role));
+
+    // Define which scanners to run for each role (simplified)
+    GenericScannerFunc active_scanners[5];
+    void* active_configs[5];
+    int num_scanners = 0;
+
+    switch (input_message->role) {
+        case ROLE_USER:
+            active_scanners[num_scanners] = (GenericScannerFunc)regex_scanner_scan;
+            active_configs[num_scanners++] = &core->regex_scanner_config;
+            active_scanners[num_scanners] = (GenericScannerFunc)prompt_guard_scanner_scan;
+            active_configs[num_scanners++] = &core->prompt_guard_config;
+            break;
+        case ROLE_ASSISTANT:
+            active_scanners[num_scanners] = (GenericScannerFunc)regex_scanner_scan;
+            active_configs[num_scanners++] = &core->regex_scanner_config;
+            // Potentially add other scanners for assistant, e.g. a specialized CodeShield
+            break;
+        // Add other roles as needed
+        default:
+            break;
+    }
+
+    CScanResult final_result = {
+        .decision = SCAN_DECISION_ALLOW,
+        .reason = strdup("Default: No applicable scanners or all allowed"),
+        .score = 0.0,
+        .status = SCAN_STATUS_SUCCESS
+    };
+    int block_encountered = 0;
+
+    for (int i = 0; i < num_scanners; ++i) {
+        if (active_scanners[i]) {
+            CScanResult scanner_result = active_scanners[i](input_message, input_trace, active_configs[i]);
+            printf("Scanner %d result: %s, score: %.2f, reason: %s\n",
+                   i, c_scan_decision_to_string(scanner_result.decision), scanner_result.score, scanner_result.reason);
+
+            if (scanner_result.decision == SCAN_DECISION_BLOCK) {
+                free_scan_result_members(&final_result); // Free previous reason
+                final_result = scanner_result; // Overwrite with block
+                block_encountered = 1;
+                break; // Block from one scanner is enough
+            } else if (scanner_result.decision == SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED) {
+                // Handle HITL - for now, treat similar to a high-scoring allow or a soft block
+                // If not already blocked, and this score is higher, update.
+                if (!block_encountered && scanner_result.score > final_result.score) {
+                    free_scan_result_members(&final_result);
+                    final_result = scanner_result;
+                } else {
+                    free_scan_result_members(&scanner_result);
+                }
+            } else if (scanner_result.decision == SCAN_DECISION_ALLOW) {
+                if (!block_encountered && scanner_result.score > final_result.score) {
+                    // If current final decision is ALLOW, take the one with higher score (less likely to be problematic)
+                    // Or, if we want to aggregate reasons, this logic needs to be more complex.
+                    // For now, just take the highest score if all are allow.
+                    // This part of the logic from Python (aggregating reasons, highest score) needs careful translation.
+                    // The current Python code: "Select BLOCK as the final decision if present ... otherwise select the decision with the highest score"
+                    // For non-block, this means we'd track the highest score.
+                    // Let's simplify: if not blocked, current highest score for non-BLOCK results.
+                     free_scan_result_members(&final_result);
+                     final_result = scanner_result;
+                } else {
+                     free_scan_result_members(&scanner_result);
+                }
+            } else { // ERROR
+                free_scan_result_members(&scanner_result); // Discard error results for now or handle them
+            }
+        }
+    }
+
+    // If no scanners were run, or all allowed but final_result reason is still default.
+    if (num_scanners == 0 && final_result.decision == SCAN_DECISION_ALLOW && strcmp(final_result.reason, "Default: No applicable scanners or all allowed") == 0) {
+        free(final_result.reason);
+        final_result.reason = strdup("No scanners configured for this role.");
+    }
+
+
+    printf("Final decision: %s, Score: %.2f, Reason: %s\n",
+           c_scan_decision_to_string(final_result.decision),
+           final_result.score,
+           final_result.reason);
+
+    return final_result;
+}
+
+// Implementations for c_..._to_string and c_..._from_string are now in llamafirewall_types.c

--- a/LlamaFirewall_C/src/llamafirewall_core.h
+++ b/LlamaFirewall_C/src/llamafirewall_core.h
@@ -1,0 +1,47 @@
+#ifndef LLAMAFIREWALL_CORE_H
+#define LLAMAFIREWALL_CORE_H
+
+#include "llamafirewall_types.h"
+#include "scanners/regex_scanner.h" // Include RegexScanner's header
+#include "scanners/prompt_guard_scanner.h" // Include PromptGuardScanner's header
+
+// Forward declaration for the scanner structure/interface
+// This might become a more concrete structure later for a scanner registry
+struct CScannerFuncs;
+
+typedef struct {
+    // For now, configuration is implicit.
+    // Later, this could hold handles to loaded scanners,
+    // configurations for which scanners to run per role, etc.
+    // Example: Map<CRole, CScannerFuncs**> role_scanners;
+    int initialized; // Simple flag to indicate if init was successful
+
+    // Configuration for the regex scanner
+    RegexScannerConfig regex_scanner_config;
+    // Configuration for the prompt guard scanner
+    PromptGuardScannerConfig prompt_guard_config;
+} LlamaFirewallCore;
+
+// Initializes the LlamaFirewallCore instance.
+// Returns 0 on success, -1 on error.
+int llamafirewall_core_init(LlamaFirewallCore* core);
+
+// Frees any resources associated with the LlamaFirewallCore instance.
+void llamafirewall_core_cleanup(LlamaFirewallCore* core);
+
+// Main scanning function.
+// Caller is responsible for allocating memory for input_message and input_trace,
+// and for freeing the returned CScanResult (specifically its char* members).
+CScanResult llamafirewall_scan_message(
+    LlamaFirewallCore* core,
+    const CMessage* input_message,
+    const CTrace* input_trace
+);
+
+// Placeholder for individual scanner function signature
+// Each scanner implementation will provide a function matching this.
+// This might be used if we have an array of generic scanner function pointers.
+typedef CScanResult (*GenericScannerFunc)(const CMessage* message, const CTrace* trace, void* scanner_specific_config);
+
+
+#endif // LLAMAFIREWALL_CORE_H

--- a/LlamaFirewall_C/src/llamafirewall_dbus_service.c
+++ b/LlamaFirewall_C/src/llamafirewall_dbus_service.c
@@ -1,0 +1,233 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h> // For ENOMEM etc.
+#include <systemd/sd-bus.h> // sd-bus library
+
+#include "llamafirewall_core.h"
+#include "llamafirewall_types.h"
+
+#define DBUS_SERVICE_NAME "io.LlamaFirewall"
+#define DBUS_OBJECT_PATH "/io/LlamaFirewall"
+#define DBUS_INTERFACE_NAME "io.LlamaFirewall.Service1"
+
+static LlamaFirewallCore firewall_core;
+static int core_initialized = 0;
+
+// Forward declaration
+static int method_scan_message(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
+// Method table for the D-Bus interface
+static const sd_bus_vtable llamafirewall_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("ScanMessage", "ssas", "ssds", method_scan_message, SD_BUS_VTABLE_UNPRIVILEGED),
+    // "ssas": input signature: string (content), string (role), array of structs (string, string) for trace
+    // "ssds": output signature: string (decision), string (reason), double (score), string (status)
+    SD_BUS_VTABLE_END
+};
+
+// Helper to initialize the core if not already done.
+static int ensure_core_initialized(sd_bus_error *ret_error) {
+    if (!core_initialized) {
+        if (llamafirewall_core_init(&firewall_core) != 0) {
+            sd_bus_error_set_const(ret_error, "io.LlamaFirewall.Error.CoreInitFailed", "Failed to initialize LlamaFirewall core.");
+            return -1;
+        }
+        core_initialized = 1;
+    }
+    return 0;
+}
+
+
+static int method_scan_message(sd_bus_message *m, void *userdata, sd_bus_error *ret_error) {
+    const char *message_content_dbus;
+    const char *message_role_dbus;
+    int r;
+
+    if (ensure_core_initialized(ret_error) < 0) {
+        // error is already set by ensure_core_initialized
+        return sd_bus_reply_method_errorf(m, ret_error->name, ret_error->message);
+    }
+
+    r = sd_bus_message_read_basic(m, 's', &message_content_dbus);
+    if (r < 0) {
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to parse message_content: %s", strerror(-r));
+        return r;
+    }
+    r = sd_bus_message_read_basic(m, 's', &message_role_dbus);
+    if (r < 0) {
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to parse message_role: %s", strerror(-r));
+        return r;
+    }
+
+    CMessage current_message;
+    current_message.role = c_role_from_string(message_role_dbus);
+    current_message.content = strdup(message_content_dbus);
+    if (!current_message.content) {
+        sd_bus_error_set_const(ret_error, SD_BUS_ERROR_NO_MEMORY, "Failed to allocate memory for message content.");
+        return -ENOMEM;
+    }
+
+
+    if (current_message.role == ROLE_UNKNOWN && strcmp(message_role_dbus, c_role_to_string(ROLE_UNKNOWN)) != 0) {
+        free(current_message.content);
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Invalid message_role: %s", message_role_dbus);
+        return sd_bus_reply_method_errorf(m, ret_error->name, ret_error->message);
+    }
+
+    CTrace current_trace = { .messages = NULL, .count = 0 };
+    CMessage* temp_trace_messages = NULL;
+    size_t temp_trace_capacity = 0;
+
+    r = sd_bus_message_enter_container(m, 'a', "(ss)");
+    if (r < 0) {
+        free(current_message.content);
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to enter trace_history array container: %s", strerror(-r));
+        return r;
+    }
+
+    while ((r = sd_bus_message_enter_container(m, 'r', "ss")) > 0) { // Enter struct
+        const char *trace_role_dbus_item, *trace_content_dbus_item;
+        r = sd_bus_message_read_basic(m, 's', &trace_role_dbus_item);
+        if (r < 0) { sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to read trace role: %s", strerror(-r)); break; }
+
+        r = sd_bus_message_read_basic(m, 's', &trace_content_dbus_item);
+        if (r < 0) { sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to read trace content: %s", strerror(-r)); break; }
+
+        if (current_trace.count >= temp_trace_capacity) {
+            temp_trace_capacity = (temp_trace_capacity == 0) ? 4 : temp_trace_capacity * 2;
+            CMessage* new_alloc = (CMessage*)realloc(temp_trace_messages, temp_trace_capacity * sizeof(CMessage));
+            if (!new_alloc) {
+                sd_bus_error_set_const(ret_error, SD_BUS_ERROR_NO_MEMORY, "Failed to reallocate trace messages.");
+                r = -ENOMEM; break;
+            }
+            temp_trace_messages = new_alloc;
+        }
+
+        CRole role_item = c_role_from_string(trace_role_dbus_item);
+        // Optional: Validate role_item if necessary, e.g., if it's ROLE_UNKNOWN
+        // and trace_role_dbus_item is not "unknown_role"
+
+        temp_trace_messages[current_trace.count].role = role_item;
+        temp_trace_messages[current_trace.count].content = strdup(trace_content_dbus_item);
+        if (!temp_trace_messages[current_trace.count].content) {
+            sd_bus_error_set_const(ret_error, SD_BUS_ERROR_NO_MEMORY, "Failed to duplicate trace item content.");
+            r = -ENOMEM; break;
+        }
+        current_trace.count++;
+        r = sd_bus_message_exit_container(m); // Exit struct
+        if (r < 0) { sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to exit trace struct container: %s", strerror(-r)); break; }
+    }
+    current_trace.messages = temp_trace_messages;
+
+    // After the loop, r might be < 0 if an error occurred, or r == 0 if sd_bus_message_enter_container for 'r' indicated end of array.
+    if (r < 0) { // Error during trace reading loop
+        for (size_t i = 0; i < current_trace.count; ++i) free(current_trace.messages[i].content);
+        free(current_trace.messages);
+        free(current_message.content);
+        // ret_error should already be set by the code inside the loop.
+        return sd_bus_reply_method_errorf(m, ret_error->name, ret_error->message);
+    }
+
+    r = sd_bus_message_exit_container(m); // Exit array
+    if (r < 0) {
+        for (size_t i = 0; i < current_trace.count; ++i) free(current_trace.messages[i].content);
+        free(current_trace.messages);
+        free(current_message.content);
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_INVALID_ARGS, "Failed to exit trace_history array container: %s", strerror(-r));
+        return r;
+    }
+
+    CScanResult scan_result = llamafirewall_scan_message(&firewall_core, &current_message, &current_trace);
+
+    free(current_message.content);
+    for (size_t i = 0; i < current_trace.count; ++i) {
+        free(current_trace.messages[i].content);
+    }
+    free(current_trace.messages);
+
+    sd_bus_message *reply = NULL;
+    r = sd_bus_message_new_method_return(m, &reply);
+    if (r < 0) {
+        sd_bus_error_set_printf(ret_error, SD_BUS_ERROR_NO_MEMORY, "Failed to create reply message: %s", strerror(-r));
+        free_scan_result_members(&scan_result);
+        return r;
+    }
+
+    const char* decision_str = c_scan_decision_to_string(scan_result.decision);
+    const char* status_str = c_scan_status_to_string(scan_result.status);
+
+    if (sd_bus_message_append_basic(reply, 's', decision_str) < 0 ||
+        sd_bus_message_append_basic(reply, 's', scan_result.reason ? scan_result.reason : "") < 0 ||
+        sd_bus_message_append_basic(reply, 'd', &scan_result.score) < 0 ||
+        sd_bus_message_append_basic(reply, 's', status_str) < 0) {
+        sd_bus_error_set_const(ret_error, SD_BUS_ERROR_NOMEM, "Failed to append to reply message."); // Simplified error
+        free_scan_result_members(&scan_result);
+        // sd_bus_message_unref(reply); // Reply is not sent, unref it.
+        return -ENOMEM; // Or appropriate error
+    }
+
+    free_scan_result_members(&scan_result);
+    return sd_bus_send(NULL, reply, NULL);
+}
+
+static void core_final_cleanup(void) {
+    if (core_initialized) {
+        llamafirewall_core_cleanup(&firewall_core);
+        core_initialized = 0;
+        printf("LlamaFirewallCore cleaned up via atexit/signal.\n");
+    }
+}
+
+int main(int argc, char *argv[]) {
+    sd_bus_slot *slot = NULL;
+    sd_bus *bus = NULL;
+    int r;
+
+    r = sd_bus_open_system(&bus);
+    if (r < 0) {
+        fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
+        goto finish;
+    }
+
+    r = sd_bus_add_object_vtable(bus, &slot, DBUS_OBJECT_PATH, DBUS_INTERFACE_NAME, llamafirewall_vtable, NULL);
+    if (r < 0) {
+        fprintf(stderr, "Failed to add object vtable: %s\n", strerror(-r));
+        goto finish;
+    }
+
+    r = sd_bus_request_name(bus, DBUS_SERVICE_NAME, 0);
+    if (r < 0) {
+        fprintf(stderr, "Failed to acquire service name '%s': %s\n", DBUS_SERVICE_NAME, strerror(-r));
+        goto finish;
+    }
+
+    printf("LlamaFirewall D-Bus service started. Listening on %s %s %s\n",
+           DBUS_SERVICE_NAME, DBUS_OBJECT_PATH, DBUS_INTERFACE_NAME);
+    printf("Press Ctrl+C to exit.\n");
+
+    atexit(core_final_cleanup); // Register cleanup function
+
+    for (;;) {
+        r = sd_bus_process(bus, NULL);
+        if (r < 0) {
+            fprintf(stderr, "Failed to process bus: %s\n", strerror(-r));
+            goto finish;
+        }
+        if (r > 0) continue;
+
+        r = sd_bus_wait(bus, (uint64_t)-1);
+        if (r < 0) {
+            fprintf(stderr, "Failed to wait for bus: %s\n", strerror(-r));
+            goto finish;
+        }
+    }
+
+finish:
+    // core_final_cleanup() will be called by atexit if main loop broken
+    // or can be called explicitly if atexit is not used for signals.
+    sd_bus_slot_unref(slot);
+    sd_bus_unref(bus);
+
+    return r < 0 ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/LlamaFirewall_C/src/llamafirewall_types.c
+++ b/LlamaFirewall_C/src/llamafirewall_types.c
@@ -1,0 +1,86 @@
+#include "llamafirewall_types.h"
+#include <string.h> // For strcmp
+#include <stdio.h>  // For NULL if not in string.h for some compilers
+
+// --- ScannerType ---
+CScannerType c_scanner_type_from_string(const char* s) {
+    if (!s) return SCANNER_TYPE_UNKNOWN;
+    if (strcmp(s, "code_shield") == 0) return SCANNER_TYPE_CODE_SHIELD;
+    if (strcmp(s, "prompt_guard") == 0) return SCANNER_TYPE_PROMPT_GUARD;
+    if (strcmp(s, "agent_alignment") == 0) return SCANNER_TYPE_AGENT_ALIGNMENT;
+    if (strcmp(s, "hidden_ascii") == 0) return SCANNER_TYPE_HIDDEN_ASCII;
+    if (strcmp(s, "pii_detection") == 0) return SCANNER_TYPE_PII_DETECTION;
+    if (strcmp(s, "regex") == 0) return SCANNER_TYPE_REGEX;
+    return SCANNER_TYPE_UNKNOWN;
+}
+
+const char* c_scanner_type_to_string(CScannerType type) {
+    switch (type) {
+        case SCANNER_TYPE_CODE_SHIELD: return "code_shield";
+        case SCANNER_TYPE_PROMPT_GUARD: return "prompt_guard";
+        case SCANNER_TYPE_AGENT_ALIGNMENT: return "agent_alignment";
+        case SCANNER_TYPE_HIDDEN_ASCII: return "hidden_ascii";
+        case SCANNER_TYPE_PII_DETECTION: return "pii_detection";
+        case SCANNER_TYPE_REGEX: return "regex";
+        default: return "unknown_scanner_type";
+    }
+}
+
+// --- ScanDecision ---
+CScanDecision c_scan_decision_from_string(const char* s) {
+    if (!s) return SCAN_DECISION_ERROR;
+    if (strcmp(s, "allow") == 0) return SCAN_DECISION_ALLOW;
+    if (strcmp(s, "human_in_the_loop_required") == 0) return SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED;
+    if (strcmp(s, "block") == 0) return SCAN_DECISION_BLOCK;
+    return SCAN_DECISION_ERROR; // Default to error if unknown string
+}
+
+const char* c_scan_decision_to_string(CScanDecision decision) {
+    switch (decision) {
+        case SCAN_DECISION_ALLOW: return "allow";
+        case SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED: return "human_in_the_loop_required";
+        case SCAN_DECISION_BLOCK: return "block";
+        case SCAN_DECISION_ERROR: return "error"; // Explicitly handle error case
+        default: return "unknown_decision";
+    }
+}
+
+// --- CRole ---
+CRole c_role_from_string(const char* s) {
+    if (!s) return ROLE_UNKNOWN;
+    if (strcmp(s, "tool") == 0) return ROLE_TOOL;
+    if (strcmp(s, "user") == 0) return ROLE_USER;
+    if (strcmp(s, "assistant") == 0) return ROLE_ASSISTANT;
+    if (strcmp(s, "memory") == 0) return ROLE_MEMORY;
+    if (strcmp(s, "system") == 0) return ROLE_SYSTEM;
+    return ROLE_UNKNOWN;
+}
+
+const char* c_role_to_string(CRole role) {
+    switch (role) {
+        case ROLE_TOOL: return "tool";
+        case ROLE_USER: return "user";
+        case ROLE_ASSISTANT: return "assistant";
+        case ROLE_MEMORY: return "memory";
+        case ROLE_SYSTEM: return "system";
+        default: return "unknown_role";
+    }
+}
+
+// --- CScanStatus ---
+CScanStatus c_scan_status_from_string(const char* s) {
+    if (!s) return SCAN_STATUS_ERROR;
+    if (strcmp(s, "success") == 0) return SCAN_STATUS_SUCCESS;
+    if (strcmp(s, "error") == 0) return SCAN_STATUS_ERROR;
+    if (strcmp(s, "skipped") == 0) return SCAN_STATUS_SKIPPED;
+    return SCAN_STATUS_ERROR; // Default to error
+}
+
+const char* c_scan_status_to_string(CScanStatus status) {
+    switch (status) {
+        case SCAN_STATUS_SUCCESS: return "success";
+        case SCAN_STATUS_ERROR: return "error";
+        case SCAN_STATUS_SKIPPED: return "skipped";
+        default: return "unknown_status";
+    }
+}

--- a/LlamaFirewall_C/src/llamafirewall_types.h
+++ b/LlamaFirewall_C/src/llamafirewall_types.h
@@ -1,0 +1,81 @@
+#ifndef LLAMAFIREWALL_TYPES_H
+#define LLAMAFIREWALL_TYPES_H
+
+#include <stddef.h> // For size_t
+#include <stdint.h> // For fixed-width integers if needed
+
+// From Python: class ScannerType(Enum):
+typedef enum {
+    SCANNER_TYPE_CODE_SHIELD,
+    SCANNER_TYPE_PROMPT_GUARD,
+    SCANNER_TYPE_AGENT_ALIGNMENT,
+    SCANNER_TYPE_HIDDEN_ASCII,
+    SCANNER_TYPE_PII_DETECTION,
+    SCANNER_TYPE_REGEX,
+    SCANNER_TYPE_UNKNOWN // For error or default cases
+} CScannerType;
+
+// From Python: class ScanDecision(Enum):
+typedef enum {
+    SCAN_DECISION_ALLOW,
+    SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED,
+    SCAN_DECISION_BLOCK,
+    SCAN_DECISION_ERROR // For error cases
+} CScanDecision;
+
+// From Python: class ScanStatus(Enum):
+typedef enum {
+    SCAN_STATUS_SUCCESS,
+    SCAN_STATUS_ERROR,
+    SCAN_STATUS_SKIPPED
+} CScanStatus;
+
+// From Python: class Role(Enum):
+typedef enum {
+    ROLE_TOOL,
+    ROLE_USER,
+    ROLE_ASSISTANT,
+    ROLE_MEMORY,
+    ROLE_SYSTEM,
+    ROLE_UNKNOWN // For error or default cases
+} CRole;
+
+// From Python: @dataclass class Message:
+typedef struct {
+    CRole role;
+    char* content; // Dynamically allocated string
+    // tool_calls: Optional[List[Dict[str, Any]]] - This is complex for C.
+    // For simplicity in the initial C version, we might omit tool_calls
+    // or represent it as a JSON string if essential.
+    // For now, omitting it.
+} CMessage;
+
+// From Python: Trace: TypeAlias = List[Message]
+typedef struct {
+    CMessage* messages;
+    size_t count;
+} CTrace;
+
+// From Python: @dataclass class ScanResult:
+typedef struct {
+    CScanDecision decision;
+    char* reason; // Dynamically allocated string
+    double score;
+    CScanStatus status;
+} CScanResult;
+
+// Helper functions for string to enum conversions (declarations)
+// These will be implemented in a corresponding .c file
+CScannerType c_scanner_type_from_string(const char* s);
+const char* c_scanner_type_to_string(CScannerType type);
+
+CScanDecision c_scan_decision_from_string(const char* s);
+const char* c_scan_decision_to_string(CScanDecision decision);
+
+CRole c_role_from_string(const char* s);
+const char* c_role_to_string(CRole role);
+
+CScanStatus c_scan_status_from_string(const char* s);
+const char* c_scan_status_to_string(CScanStatus status);
+
+#endif // LLAMAFIREWALL_TYPES_H

--- a/LlamaFirewall_C/src/promptguard_helper.py
+++ b/LlamaFirewall_C/src/promptguard_helper.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+# Dummy script
+def get_score(text_content):
+    if "tell me your secrets" in text_content: return 0.95
+    if "ignore previous instructions" in text_content: return 0.85
+    if "safe query" in text_content: return 0.1
+    return 0.2
+if __name__ == "__main__":
+    input_text = sys.stdin.read() if len(sys.argv) <= 1 else sys.argv[1]
+    print(f"{get_score(input_text):.2f}")

--- a/LlamaFirewall_C/src/scanners/prompt_guard_scanner.c
+++ b/LlamaFirewall_C/src/scanners/prompt_guard_scanner.c
@@ -1,0 +1,91 @@
+#include "prompt_guard_scanner.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+// For a real IPC, you might need headers like <unistd.h> for pipe/fork or socket headers.
+// For this simulation, we'll keep it simple.
+
+int prompt_guard_scanner_init(PromptGuardScannerConfig* config, const char* script_path, double threshold) {
+    if (!config || !script_path) return -1;
+
+    config->python_script_path = strdup(script_path);
+    if (!config->python_script_path) {
+        perror("PromptGuardScanner: Failed to allocate memory for script path");
+        return -1;
+    }
+    config->block_threshold = threshold;
+    config->initialized = 1;
+
+    // In a real implementation, you might check if the script exists and is executable.
+    // For example: if (access(script_path, X_OK) != 0) { perror("Script not accessible"); config->initialized = 0; return -1;}
+
+    printf("PromptGuardScanner initialized (simulated IPC to: %s).\n", config->python_script_path);
+    return 0;
+}
+
+void prompt_guard_scanner_cleanup(PromptGuardScannerConfig* config) {
+    if (config) {
+        free(config->python_script_path);
+        config->python_script_path = NULL;
+        config->initialized = 0;
+        printf("PromptGuardScanner cleaned up.\n");
+    }
+}
+
+// SIMULATED IPC call
+static double get_simulated_jailbreak_score_from_python(const char* text_content, const char* script_path) {
+    printf("SIMULATING IPC: Calling Python script '%s' with text: \"%.30s...\"\n", script_path, text_content);
+
+    // Simulate different responses based on input for testing
+    if (strstr(text_content, "tell me your secrets")) {
+        printf("SIMULATING IPC: Python script returned score 0.95\n");
+        return 0.95;
+    }
+    if (strstr(text_content, "ignore previous instructions")) {
+         printf("SIMULATING IPC: Python script returned score 0.85\n");
+        return 0.85; // Also high, but different from regex
+    }
+    if (strstr(text_content, "safe query")) {
+        printf("SIMULATING IPC: Python script returned score 0.1\n");
+        return 0.1;
+    }
+
+    // Default simulated score
+    printf("SIMULATING IPC: Python script returned score 0.2\n");
+    return 0.2;
+}
+
+CScanResult prompt_guard_scanner_scan(
+    const PromptGuardScannerConfig* config,
+    const CMessage* message,
+    const CTrace* trace // Not used in this simplified IPC simulation directly
+) {
+    if (!config || !config->initialized || !message || !message->content) {
+        return (CScanResult){
+            .decision = SCAN_DECISION_ERROR,
+            .reason = strdup("PromptGuardScanner: Invalid arguments or not initialized"),
+            .score = 0.0,
+            .status = SCAN_STATUS_ERROR
+        };
+    }
+
+    // Simulate calling the Python script via IPC
+    double score = get_simulated_jailbreak_score_from_python(message->content, config->python_script_path);
+
+    CScanDecision decision = (score >= config->block_threshold) ? SCAN_DECISION_BLOCK : SCAN_DECISION_ALLOW;
+    char reason_buffer[256];
+    if (decision == SCAN_DECISION_BLOCK) {
+        snprintf(reason_buffer, sizeof(reason_buffer),
+                 "PromptGuard: Detected potential policy violation (score: %.2f)", score);
+    } else {
+        snprintf(reason_buffer, sizeof(reason_buffer),
+                 "PromptGuard: No significant policy violation detected (score: %.2f)", score);
+    }
+
+    return (CScanResult){
+        .decision = decision,
+        .reason = strdup(reason_buffer),
+        .score = score,
+        .status = SCAN_STATUS_SUCCESS
+    };
+}

--- a/LlamaFirewall_C/src/scanners/prompt_guard_scanner.h
+++ b/LlamaFirewall_C/src/scanners/prompt_guard_scanner.h
@@ -1,0 +1,26 @@
+#ifndef PROMPT_GUARD_SCANNER_H
+#define PROMPT_GUARD_SCANNER_H
+
+#include "../llamafirewall_types.h"
+
+typedef struct {
+    // Configuration for PromptGuard, e.g., path to Python helper script, timeout
+    char* python_script_path; // Example: "/opt/llamafirewall/promptguard_helper.py"
+    double block_threshold;
+    int initialized;
+} PromptGuardScannerConfig;
+
+// Initializes the PromptGuardScanner (e.g., checks if script exists)
+int prompt_guard_scanner_init(PromptGuardScannerConfig* config, const char* script_path, double threshold);
+
+// Frees resources
+void prompt_guard_scanner_cleanup(PromptGuardScannerConfig* config);
+
+// Scan function for PromptGuardScanner
+CScanResult prompt_guard_scanner_scan(
+    const PromptGuardScannerConfig* config,
+    const CMessage* message,
+    const CTrace* trace
+);
+
+#endif // PROMPT_GUARD_SCANNER_H

--- a/LlamaFirewall_C/src/scanners/regex_scanner.c
+++ b/LlamaFirewall_C/src/scanners/regex_scanner.c
@@ -1,0 +1,170 @@
+#include "regex_scanner.h"
+#include <pcre2.h> // PCRE2 library for regex
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Default regex patterns (similar to the Python version)
+// Using an array of structs for easier initialization
+typedef struct {
+    const char* name;
+    const char* pattern;
+} DefaultPattern;
+
+static const DefaultPattern DEFAULT_REGEX_PATTERNS_DATA[] = {
+    {"Prompt injection", "ignore previous instructions|ignore all instructions"},
+    {"Email address", "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b"},
+    {"Phone number", "\\b(\\+\\d{1,2}\\s?)?\\(?\\d{3}\\)?[\\s.-]?\\d{3}[\\s.-]?\\d{4}\\b"},
+    // {"Credit card", "\\b(?:\\d{4}[- ]?){3}\\d{4}\\b"}, // PCRE2 might need different syntax for non-capturing group, or just use capturing
+    {"Credit card", "\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b"},
+    {"Social security number", "\\b\\d{3}-\\d{2}-\\d{4}\\b"}
+};
+static const size_t NUM_DEFAULT_PATTERNS = sizeof(DEFAULT_REGEX_PATTERNS_DATA) / sizeof(DEFAULT_REGEX_PATTERNS_DATA[0]);
+
+int regex_scanner_init(RegexScannerConfig* config) {
+    if (!config) return -1;
+
+    config->patterns = (RegexPattern*)malloc(NUM_DEFAULT_PATTERNS * sizeof(RegexPattern));
+    if (!config->patterns) {
+        perror("Failed to allocate memory for regex patterns");
+        return -1;
+    }
+    config->num_patterns = 0; // Will be incremented as patterns are successfully compiled
+
+    int error_code;
+    PCRE2_SIZE error_offset;
+
+    for (size_t i = 0; i < NUM_DEFAULT_PATTERNS; ++i) {
+        pcre2_code* re = pcre2_compile(
+            (PCRE2_SPTR)DEFAULT_REGEX_PATTERNS_DATA[i].pattern, // pattern
+            PCRE2_ZERO_TERMINATED, // string is zero-terminated
+            PCRE2_CASELESS | PCRE2_DOTALL, // options
+            &error_code,      // for error code
+            &error_offset,    // for error offset
+            NULL              // use default compile context
+        );
+
+        if (re == NULL) {
+            PCRE2_UCHAR buffer[256];
+            pcre2_get_error_message(error_code, buffer, sizeof(buffer));
+            fprintf(stderr, "PCRE2 compilation failed for '%s' at offset %d: %s\n",
+                    DEFAULT_REGEX_PATTERNS_DATA[i].name, (int)error_offset, buffer);
+            // Do not add this pattern, continue with others
+            continue;
+        }
+        config->patterns[config->num_patterns].name = strdup(DEFAULT_REGEX_PATTERNS_DATA[i].name);
+        config->patterns[config->num_patterns].compiled_pattern = re;
+        config->num_patterns++;
+    }
+
+    // If no patterns compiled successfully, it might be an issue.
+    if (config->num_patterns == 0 && NUM_DEFAULT_PATTERNS > 0) {
+        fprintf(stderr, "RegexScanner: Warning - no regex patterns were successfully compiled.\n");
+        // Depending on desired strictness, could return -1 here.
+    }
+
+    config->block_threshold = 1.0; // Standard for regex: a match is a block.
+    printf("RegexScanner initialized with %zu patterns.\n", config->num_patterns);
+    return 0;
+}
+
+void regex_scanner_cleanup(RegexScannerConfig* config) {
+    if (!config || !config->patterns) return;
+
+    for (size_t i = 0; i < config->num_patterns; ++i) {
+        free(config->patterns[i].name);
+        if (config->patterns[i].compiled_pattern) {
+            pcre2_code_free((pcre2_code*)config->patterns[i].compiled_pattern);
+        }
+    }
+    free(config->patterns);
+    config->patterns = NULL;
+    config->num_patterns = 0;
+    printf("RegexScanner cleaned up.\n");
+}
+
+CScanResult regex_scanner_scan(
+    const RegexScannerConfig* config,
+    const CMessage* message,
+    const CTrace* trace // Not used by this scanner
+) {
+    if (!config || !message || !message->content) {
+        return (CScanResult){
+            .decision = SCAN_DECISION_ERROR,
+            .reason = strdup("RegexScanner: Invalid arguments or uninitialized"),
+            .score = 0.0,
+            .status = SCAN_STATUS_ERROR
+        };
+    }
+
+    // Each pattern has its own pcre2_code, so match_data should be created per pattern,
+    // or more efficiently, a single match_data created with pcre2_match_data_create
+    // and large enough for any of the patterns.
+    // For simplicity here, we'll create it inside the loop if needed, or pass NULL if the pattern
+    // doesn't need to store captures (which these don't explicitly).
+    // However, pcre2_match requires a match_data block.
+
+    pcre2_match_data* match_data = NULL; // Will be created from the first valid pattern
+
+    for (size_t i = 0; i < config->num_patterns; ++i) {
+        if (!config->patterns[i].compiled_pattern) continue; // Skip if compilation failed
+
+        if (match_data == NULL) { // Create match_data using the first available compiled pattern
+             match_data = pcre2_match_data_create_from_pattern(
+                (const pcre2_code*)config->patterns[i].compiled_pattern, NULL);
+             if (match_data == NULL) {
+                return (CScanResult){
+                    .decision = SCAN_DECISION_ERROR,
+                    .reason = strdup("RegexScanner: Failed to create match_data"),
+                    .score = 0.0,
+                    .status = SCAN_STATUS_ERROR};
+            }
+        }
+
+
+        int rc = pcre2_match(
+            (const pcre2_code*)config->patterns[i].compiled_pattern, // compiled pattern
+            (PCRE2_SPTR)message->content, // subject string
+            PCRE2_ZERO_TERMINATED, // length of subject
+            0,                     // start offset in subject
+            0,                     // options
+            match_data,            // block for storing results
+            NULL                   // use default match context
+        );
+
+        if (rc >= 0) { // Match found
+            char* reason_str;
+            int len = snprintf(NULL, 0, "Regex match: %s", config->patterns[i].name);
+            reason_str = (char*)malloc(len + 1);
+            if (reason_str) {
+                 sprintf(reason_str, "Regex match: %s", config->patterns[i].name);
+            } else {
+                 reason_str = strdup("Regex match: <unknown pattern name - alloc error>"); // Fallback
+            }
+
+            if (match_data) pcre2_match_data_free(match_data);
+            return (CScanResult){
+                .decision = SCAN_DECISION_BLOCK,
+                .reason = reason_str,
+                .score = 1.0, // Full block score
+                .status = SCAN_STATUS_SUCCESS
+            };
+        } else if (rc == PCRE2_ERROR_NOMATCH) {
+            // No match, continue to next pattern
+        } else {
+            // Some other error
+            PCRE2_UCHAR buffer[120];
+            pcre2_get_error_message(rc, buffer, sizeof(buffer));
+            fprintf(stderr, "RegexScanner: Match error for pattern '%s': %s\n", config->patterns[i].name, buffer);
+            // Potentially return an error or just skip this pattern
+        }
+    }
+
+    if (match_data) pcre2_match_data_free(match_data);
+    return (CScanResult){
+        .decision = SCAN_DECISION_ALLOW,
+        .reason = strdup("RegexScanner: No patterns matched"),
+        .score = 0.0,
+        .status = SCAN_STATUS_SUCCESS
+    };
+}

--- a/LlamaFirewall_C/src/scanners/regex_scanner.h
+++ b/LlamaFirewall_C/src/scanners/regex_scanner.h
@@ -1,0 +1,35 @@
+#ifndef REGEX_SCANNER_H
+#define REGEX_SCANNER_H
+
+#include "../llamafirewall_types.h" // For CMessage, CTrace, CScanResult
+#include <stddef.h> // For size_t
+
+// Define a structure to hold the RegexScanner's state, including compiled patterns.
+// We will use PCRE2 for regex compilation and matching.
+// The actual pcre2_code type will be included in the .c file.
+typedef struct RegexPattern {
+    char* name;
+    void* compiled_pattern; // To be cast to pcre2_code*
+} RegexPattern;
+
+typedef struct {
+    RegexPattern* patterns;
+    size_t num_patterns;
+    double block_threshold; // Though for regex, it's usually a direct match/block
+} RegexScannerConfig;
+
+// Initializes the RegexScanner, compiles patterns.
+// Returns 0 on success, -1 on error.
+int regex_scanner_init(RegexScannerConfig* config);
+
+// Frees resources used by the RegexScanner (compiled patterns).
+void regex_scanner_cleanup(RegexScannerConfig* config);
+
+// Scan function for the RegexScanner.
+CScanResult regex_scanner_scan(
+    const RegexScannerConfig* config,
+    const CMessage* message,
+    const CTrace* trace // trace might not be used by this specific scanner
+);
+
+#endif // REGEX_SCANNER_H

--- a/LlamaFirewall_C/tests/test_helpers.h
+++ b/LlamaFirewall_C/tests/test_helpers.h
@@ -1,0 +1,40 @@
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include "../src/llamafirewall_types.h" // For CMessage, CRole, CScanResult etc.
+
+// Define colors for test output (optional, works on ANSI terminals)
+#define KGRN  "\x1B[32m"
+#define KRED  "\x1B[31m"
+#define KNRM  "\x1B[0m"
+
+#define TEST_PASSED(test_name) printf("%s[PASS]%s %s\n", KGRN, KNRM, test_name)
+#define TEST_FAILED(test_name, reason) printf("%s[FAIL]%s %s - Reason: %s\n", KRED, KNRM, test_name, reason); test_suite_failed = 1
+
+static int test_suite_failed = 0;
+
+static inline CMessage create_test_message(CRole role, const char* content) {
+    CMessage msg;
+    msg.role = role;
+    msg.content = strdup(content);
+    return msg;
+}
+
+static inline void free_test_message_content(CMessage* msg) {
+    if (msg && msg->content) {
+        free(msg->content);
+        msg->content = NULL;
+    }
+}
+
+// Local version for tests, as original is static in llamafirewall_core.c
+static inline void free_scan_result_members(CScanResult* result) {
+    if (result && result->reason) {
+        free(result->reason);
+        result->reason = NULL;
+    }
+}

--- a/LlamaFirewall_C/tests/test_llamafirewall_types.c
+++ b/LlamaFirewall_C/tests/test_llamafirewall_types.c
@@ -1,0 +1,40 @@
+#include "../src/llamafirewall_types.h"
+#include "test_helpers.h"
+
+void test_role_conversions() {
+    const char* test_name = "RoleConversions";
+    if (c_role_from_string("user") == ROLE_USER && strcmp(c_role_to_string(ROLE_USER), "user") == 0 &&
+        c_role_from_string("assistant") == ROLE_ASSISTANT && strcmp(c_role_to_string(ROLE_ASSISTANT), "assistant") == 0 &&
+        c_role_from_string("invalid_role") == ROLE_UNKNOWN && strcmp(c_role_to_string(ROLE_UNKNOWN), "unknown_role") == 0) {
+        TEST_PASSED(test_name);
+    } else {
+        TEST_FAILED(test_name, "Mismatch in role string/enum conversion");
+    }
+}
+
+void test_decision_conversions() {
+    const char* test_name = "DecisionConversions";
+     if (c_scan_decision_from_string("allow") == SCAN_DECISION_ALLOW && strcmp(c_scan_decision_to_string(SCAN_DECISION_ALLOW), "allow") == 0 &&
+        c_scan_decision_from_string("block") == SCAN_DECISION_BLOCK && strcmp(c_scan_decision_to_string(SCAN_DECISION_BLOCK), "block") == 0 &&
+        c_scan_decision_from_string("human_in_the_loop_required") == SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED &&
+         strcmp(c_scan_decision_to_string(SCAN_DECISION_HUMAN_IN_THE_LOOP_REQUIRED), "human_in_the_loop_required") == 0 &&
+        c_scan_decision_from_string("invalid_decision") == SCAN_DECISION_ERROR && strcmp(c_scan_decision_to_string(SCAN_DECISION_ERROR), "error") == 0 ) {
+        TEST_PASSED(test_name);
+    } else {
+        TEST_FAILED(test_name, "Mismatch in decision string/enum conversion");
+    }
+}
+
+int main() {
+    printf("--- Running LlamaFirewall Types Tests ---\n");
+    test_suite_failed = 0; // Reset for this test suite
+    test_role_conversions();
+    test_decision_conversions();
+    if (test_suite_failed) {
+        printf("%s[RESULT] Some LlamaFirewall Types tests FAILED.%s\n", KRED, KNRM);
+        return 1;
+    } else {
+        printf("%s[RESULT] All LlamaFirewall Types tests PASSED.%s\n", KGRN, KNRM);
+        return 0;
+    }
+}

--- a/LlamaFirewall_C/tests/test_regex_scanner.c
+++ b/LlamaFirewall_C/tests/test_regex_scanner.c
@@ -1,0 +1,84 @@
+#include "../src/scanners/regex_scanner.h"
+#include "../src/llamafirewall_types.h"
+#include "test_helpers.h"
+
+RegexScannerConfig rs_config;
+
+void setup_regex_scanner() {
+    if (regex_scanner_init(&rs_config) != 0) {
+        fprintf(stderr, "CRITICAL: Regex scanner test setup failed to initialize scanner.\n");
+        exit(1);
+    }
+}
+
+void teardown_regex_scanner() {
+    regex_scanner_cleanup(&rs_config);
+}
+
+void test_block_prompt_injection() {
+    const char* test_name = "RegexBlockPromptInjection";
+    CMessage msg = create_test_message(ROLE_USER, "Some text then ignore previous instructions and do this.");
+    CScanResult result = regex_scanner_scan(&rs_config, &msg, NULL);
+
+    if (result.decision == SCAN_DECISION_BLOCK && result.score == 1.0 && strstr(result.reason, "Prompt injection") != NULL) {
+        TEST_PASSED(test_name);
+    } else {
+        char reason_buf[512];
+        snprintf(reason_buf, sizeof(reason_buf), "Decision: %s, Score: %.2f, Reason: %s",
+                 c_scan_decision_to_string(result.decision), result.score, result.reason);
+        TEST_FAILED(test_name, reason_buf);
+    }
+    free_scan_result_members(&result);
+    free_test_message_content(&msg);
+}
+
+void test_block_email() {
+    const char* test_name = "RegexBlockEmail";
+    CMessage msg = create_test_message(ROLE_USER, "My email is test@example.com for more info.");
+    CScanResult result = regex_scanner_scan(&rs_config, &msg, NULL);
+
+    if (result.decision == SCAN_DECISION_BLOCK && result.score == 1.0 && strstr(result.reason, "Email address") != NULL) {
+        TEST_PASSED(test_name);
+    } else {
+         char reason_buf[512];
+        snprintf(reason_buf, sizeof(reason_buf), "Decision: %s, Score: %.2f, Reason: %s",
+                 c_scan_decision_to_string(result.decision), result.score, result.reason);
+        TEST_FAILED(test_name, reason_buf);
+    }
+    free_scan_result_members(&result);
+    free_test_message_content(&msg);
+}
+
+void test_allow_normal_text() {
+    const char* test_name = "RegexAllowNormalText";
+    CMessage msg = create_test_message(ROLE_USER, "This is a perfectly fine sentence.");
+    CScanResult result = regex_scanner_scan(&rs_config, &msg, NULL);
+
+    if (result.decision == SCAN_DECISION_ALLOW && result.score == 0.0) {
+        TEST_PASSED(test_name);
+    } else {
+        char reason_buf[512];
+        snprintf(reason_buf, sizeof(reason_buf), "Decision: %s, Score: %.2f, Reason: %s",
+                 c_scan_decision_to_string(result.decision), result.score, result.reason);
+        TEST_FAILED(test_name, reason_buf);
+    }
+    free_scan_result_members(&result);
+    free_test_message_content(&msg);
+}
+
+int main() {
+    printf("--- Running RegexScanner Tests ---\n");
+    test_suite_failed = 0; // Reset for this test suite
+    setup_regex_scanner();
+    test_block_prompt_injection();
+    test_block_email();
+    test_allow_normal_text();
+    teardown_regex_scanner();
+    if (test_suite_failed) {
+        printf("%s[RESULT] Some RegexScanner tests FAILED.%s\n", KRED, KNRM);
+        return 1;
+    } else {
+        printf("%s[RESULT] All RegexScanner tests PASSED.%s\n", KGRN, KNRM);
+        return 0;
+    }
+}


### PR DESCRIPTION
This commit introduces a C implementation of the LlamaFirewall, designed to run as a D-Bus service in a Yocto Linux environment.

Key accomplishments:

1.  **Core C Implementation:**
    *   I ported core firewall logic, message/trace handling, and data
        structures (`CMessage`, `CScanResult`, etc.) to C.
        (Files: `llamafirewall_core.c`, `llamafirewall_types.c`)

2.  **Scanners:**
    *   `RegexScanner`: I fully implemented this in C using `pcre2`.
    *   `PromptGuardScanner`: I implemented the C-side of a hybrid
        (C-Python IPC) approach. This version simulates the IPC call.
        A dummy Python helper script (`promptguard_helper.py`) is included.
        (Files: `scanners/regex_scanner.c`, `scanners/prompt_guard_scanner.c`)

3.  **D-Bus Service:**
    *   I exposed firewall functionality via D-Bus (`io.LlamaFirewall` service)
        using `sd-bus`. The primary method is `ScanMessage(ssas -> ssds)`.
        (File: `llamafirewall_dbus_service.c`)

4.  **Build & Deployment:**
    *   I created a `Makefile` for compiling the C service and unit tests.
    *   I developed a Yocto recipe (`recipes-security/llamafirewall-c/llamafirewall-c_0.1.bb`)
        for building and installing the service, D-Bus configuration,
        Python helper, and dependencies (pcre2, systemd, python3).
    *   I added a D-Bus service file (`conf/io.LlamaFirewall.service`).

5.  **Testing & Documentation:**
    *   I wrote basic C unit tests for `llamafirewall_types` and `regex_scanner`.
    *   I updated `README.md` to document the C project, build process, D-Bus API,
        and Yocto integration.

This conversion allows LlamaFirewall components to be used in environments where a C-based D-Bus service is preferred, such as Yocto systems, while providing a path for integrating Python-based ML scanners via IPC.