### PR TITLE
Fixing field name mismatch in CyberSOCEval malware analysis prompt generation

### DIFF
--- a/CybersecurityBenchmarks/benchmark/crwd_meta/malware_analysis.py
+++ b/CybersecurityBenchmarks/benchmark/crwd_meta/malware_analysis.py
@@ -163,7 +163,7 @@ class MalwareAnalysisBenchmark(Benchmark):
         sha256 = cast(str, test_case.get("sha256"))
         attack_type = cast(str, test_case.get("attack"))
         report = self._get_report(sha256, attack_type)
-        question = test_case.get("question_text")
+        question = test_case.get("question")
         options = test_case.get("options")
 
         truncated_report = copy.deepcopy(report)


### PR DESCRIPTION
This PR fixes a critical bug in the CyberSOCEval4 Malware Analysis benchmark where prompts were being generated with "None" as the question text. The issue was caused by a field name mismatch in malware_analysis.py. The code was attempting to retrieve the question using test_case.get("question_text"), but the actual dataset file (questions.json) stores the question under the field name "question". This caused all prompts to be generated with the literal string "None" instead of the actual question text, resulting in prompts like "Answer the following multi-choice question: None." being sent to the models under test. The fix changes the field accessor from "question_text" to "question" to match the dataset schema, ensuring that the actual question text is properly included in the generated prompts.