### PR TITLE
fix: Use DATASETS env var for arvo_meta paths instead of pk…

### DIFF
--- a/CybersecurityBenchmarks/benchmark/arvo_utils.py
+++ b/CybersecurityBenchmarks/benchmark/arvo_utils.py
@@ -8,6 +8,7 @@
 import asyncio
 import json
 import logging
+import os
 import re
 import subprocess
 import tempfile
@@ -101,6 +102,20 @@ def get_all_least_common_ancestors(
         f"FOUND LCAs with avg {sum_losses/len(ground_truth_stacktraces)} lost frames out of {sum_len / len(ground_truth_stacktraces)}: {repr(res)}",
     )
     return list(res)
+
+
+def get_arvo_meta_path(filename: str) -> Path:
+    """
+    Get the path to an arvo_meta file using the DATASETS environment variable.
+    Raises RuntimeError if DATASETS is not set.
+    """
+    datasets_path = os.getenv("DATASETS")
+    if not datasets_path:
+        raise RuntimeError(
+            "DATASETS environment variable must be set. "
+            "Example: export DATASETS=/path/to/PurpleLlama/CybersecurityBenchmarks/datasets"
+        )
+    return Path(datasets_path) / "autopatch" / "arvo_meta" / filename
 
 
 class ArvoContainer:
@@ -1015,17 +1030,13 @@ class ArvoContainer:
 
     def _load_ground_truth_patches(self) -> List[Dict[str, Any]]:
         """Load the ground truth patch data from the arvo_meta directory."""
-        gt_patch_path = pkg_resources.resource_filename(
-            __name__, f"arvo_meta/{self.arvo_id}-patch.json"
-        )
+        gt_patch_path = get_arvo_meta_path(f"{self.arvo_id}-patch.json")
         with open(gt_patch_path, "r") as f:
             return json.load(f)
 
     def _load_arvo_metadata(self) -> Dict[str, Any]:
         """Load ARVO metadata"""
-        gt_patch_path = pkg_resources.resource_filename(
-            __name__, f"arvo_meta/{self.arvo_id}-meta.json"
-        )
+        gt_patch_path = get_arvo_meta_path(f"{self.arvo_id}-meta.json")
         with open(gt_patch_path, "r") as f:
             return json.load(f)
 

--- a/CybersecurityBenchmarks/benchmark/autopatching_benchmark.py
+++ b/CybersecurityBenchmarks/benchmark/autopatching_benchmark.py
@@ -23,7 +23,7 @@ from typing import Any, Callable, Coroutine, Dict, Optional, Union
 
 import pkg_resources
 
-from .arvo_utils import ArvoContainer
+from .arvo_utils import ArvoContainer, get_arvo_meta_path
 
 from .autopatch.autopatch_tools import AutoPatchAgent
 from .autopatch.report import ChatHistory, write_chat_history_markdown
@@ -365,9 +365,7 @@ class AutoPatchingBenchmark(Benchmark):
         YELLOW = "\033[1m\033[93m"
         END = "" "\033[0m"
         BLUE = "\033[1m\033[94m"
-        metadata_path = pkg_resources.resource_filename(
-            __name__, f"arvo_meta/{case_id}-meta.json"
-        )
+        metadata_path = get_arvo_meta_path(f"{case_id}-meta.json")
         if not metadata_path.exists():
             logging.warning(
                 f"Metadata file not found for case {case_id}: {metadata_path}"
@@ -426,9 +424,7 @@ class AutoPatchingBenchmark(Benchmark):
                 fix_container.logger.info(
                     f"{BLUE}Found correct fix for {case_id} is {found_commit} {END}"
                 )
-                patch_path = pkg_resources.resource_filename(
-                    __name__, f"arvo_meta/{case_id}-patch.json"
-                )
+                patch_path = get_arvo_meta_path(f"{case_id}-patch.json")
                 with open(patch_path, "r") as f:
                     patch_dict = json.load(f)[0]
                 metadata_json["arvo_metadata"]["fix_commit"] = found_commit


### PR DESCRIPTION
…g_resources

Fixes critical FileNotFoundError that breaks the benchmark during agent evaluation post fix when loading ground truth json patches by using DATASETS env variable to locate arvo_meta files in datasets/autopatch/arvo_meta/ instead of hardcoded benchmark/arvo_meta/ path return via pkg_resources.

- Add get_arvo_meta_path() helper that reads DATASETS env var
- Raises RuntimeError with clear message if DATASETS not set
- Update all arvo_meta path references to use new helper