### PR TITLE
Fix tokenizer regex warning by setting fix_mistral_regex=True

### DIFF
--- a/LlamaFirewall/src/llamafirewall/cli/configure.py
+++ b/LlamaFirewall/src/llamafirewall/cli/configure.py
@@ -100,7 +100,9 @@ def download_model(model_name: str = DEFAULT_MODEL_NAME) -> bool:
         # Download and save the model and tokenizer
         print(f"Downloading model {model_name}...")
         model = AutoModelForSequenceClassification.from_pretrained(model_name)
-        tokenizer = AutoTokenizer.from_pretrained(model_name)
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name, fix_mistral_regex=True
+        )
 
         # Save the model and tokenizer locally
         model.save_pretrained(model_path)

--- a/LlamaFirewall/src/llamafirewall/scanners/promptguard_utils.py
+++ b/LlamaFirewall/src/llamafirewall/scanners/promptguard_utils.py
@@ -63,14 +63,18 @@ class PromptGuard:
                 login()
             # Load the model and tokenizer from Hugging Face
             model = AutoModelForSequenceClassification.from_pretrained(model_name)
-            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_name, fix_mistral_regex=True
+            )
             # Save the model and tokenizer locally
             model.save_pretrained(model_path)
             tokenizer.save_pretrained(model_path)
         else:
             # Load the model and tokenizer from the local path
             model = AutoModelForSequenceClassification.from_pretrained(model_path)
-            tokenizer = AutoTokenizer.from_pretrained(model_path)
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_path, fix_mistral_regex=True
+            )
 
         return model, tokenizer
 


### PR DESCRIPTION
Summary
- Added `fix_mistral_regex=True` parameter to `AutoTokenizer.from_pretrained()` calls in PromptGuard
- This eliminates the incorrect regex pattern warning when loading the Llama-Prompt-Guard tokenizer

Changes
- `LlamaFirewall/src/llamafirewall/scanners/promptguard_utils.py` - Fixed both tokenizer loading locations
- `LlamaFirewall/src/llamafirewall/cli/configure.py` - Fixed tokenizer loading in download function

Test plan
- [ ] Run LlamaFirewall basic usage example and verify no regex warning appears
- [ ] Verify tokenizer loads correctly with the fix applied

Fixes #158