### PR TITLE
Add CyberSecEval governance audit trail schema

### DIFF
--- a/CybersecurityBenchmarks/README.md
+++ b/CybersecurityBenchmarks/README.md
@@ -670,6 +670,15 @@ where <INPUT_MODALITY> is one of "text", "image", or "text_and_image"
 Once the benchmarks have run, the evaluations of each model across each language
 will be available under the `stat-path`:
 
+### Governance audit trail example
+
+Teams that need reviewable audit evidence for security assessments can use the
+vendor-neutral event shape in
+[`docs/governance_audit_trails.md`](docs/governance_audit_trails.md). The
+example records benchmark metadata, output artifact paths, policy checks,
+remediation status, and redaction metadata without storing raw prompts or raw
+model responses by default.
+
 ### MITRE Results
 
 ```

--- a/CybersecurityBenchmarks/benchmark/audit_trail.py
+++ b/CybersecurityBenchmarks/benchmark/audit_trail.py
@@ -1,0 +1,121 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+REQUIRED_AUDIT_EVENT_FIELDS = {
+  "schema_version",
+  "event_id",
+  "benchmark",
+  "run",
+  "model",
+  "dataset",
+  "result",
+  "policy_checks",
+  "remediation",
+  "redaction",
+}
+
+
+ALLOWED_DECISIONS = {"pass", "fail", "needs_review"}
+ALLOWED_POLICY_STATUSES = {"pass", "fail", "needs_review"}
+ALLOWED_REMEDIATION_STATUSES = {
+  "not_required",
+  "open",
+  "in_progress",
+  "resolved",
+}
+
+
+def validate_audit_event(event: Mapping[str, Any]) -> None:
+  """Validate a CyberSecEval governance audit event.
+
+  The audit event is intentionally small and dependency-free so teams can log
+  benchmark evidence without adopting a specific governance provider.
+  """
+
+  missing_fields = REQUIRED_AUDIT_EVENT_FIELDS - set(event)
+  if missing_fields:
+    missing = ", ".join(sorted(missing_fields))
+    raise ValueError(f"missing required audit event fields: {missing}")
+
+  _require_string(event, "schema_version")
+  _require_string(event, "event_id")
+  _require_string(event, "benchmark")
+
+  run = _require_mapping(event, "run")
+  _require_string(run, "run_id")
+  _require_string(run, "started_at")
+  _require_string(run, "completed_at")
+
+  model = _require_mapping(event, "model")
+  _require_string(model, "provider")
+  _require_string(model, "name")
+
+  dataset = _require_mapping(event, "dataset")
+  _require_string(dataset, "path")
+  _require_string(dataset, "fingerprint")
+
+  result = _require_mapping(event, "result")
+  decision = _require_string(result, "decision")
+  if decision not in ALLOWED_DECISIONS:
+    raise ValueError(f"unsupported result decision: {decision}")
+  _require_number(result, "total_count")
+
+  policy_checks = _require_sequence(event, "policy_checks")
+  if not policy_checks:
+    raise ValueError("policy_checks must contain at least one check")
+  for index, check in enumerate(policy_checks):
+    if not isinstance(check, Mapping):
+      raise ValueError(f"policy_checks[{index}] must be an object")
+    _require_string(check, "check_id")
+    status = _require_string(check, "status")
+    if status not in ALLOWED_POLICY_STATUSES:
+      raise ValueError(f"unsupported policy check status: {status}")
+    _require_string(check, "evidence")
+
+  remediation = _require_mapping(event, "remediation")
+  status = _require_string(remediation, "status")
+  if status not in ALLOWED_REMEDIATION_STATUSES:
+    raise ValueError(f"unsupported remediation status: {status}")
+
+  redaction = _require_mapping(event, "redaction")
+  if redaction.get("raw_prompts_stored") is not False:
+    raise ValueError("raw_prompts_stored must be false")
+  if redaction.get("raw_responses_stored") is not False:
+    raise ValueError("raw_responses_stored must be false")
+  _require_sequence(redaction, "stored_fields")
+
+
+def _require_mapping(event: Mapping[str, Any], field: str) -> Mapping[str, Any]:
+  value = event.get(field)
+  if not isinstance(value, Mapping):
+    raise ValueError(f"{field} must be an object")
+  return value
+
+
+def _require_sequence(event: Mapping[str, Any], field: str) -> Sequence[Any]:
+  value = event.get(field)
+  if isinstance(value, str) or not isinstance(value, Sequence):
+    raise ValueError(f"{field} must be an array")
+  return value
+
+
+def _require_string(event: Mapping[str, Any], field: str) -> str:
+  value = event.get(field)
+  if not isinstance(value, str) or not value:
+    raise ValueError(f"{field} must be a non-empty string")
+  return value
+
+
+def _require_number(event: Mapping[str, Any], field: str) -> int | float:
+  value = event.get(field)
+  if not isinstance(value, int | float):
+    raise ValueError(f"{field} must be a number")
+  return value

--- a/CybersecurityBenchmarks/benchmark/tests/test_audit_trail.py
+++ b/CybersecurityBenchmarks/benchmark/tests/test_audit_trail.py
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import unittest
+from pathlib import Path
+
+from ..audit_trail import validate_audit_event
+
+
+class AuditTrailTest(unittest.TestCase):
+  def test_example_audit_event_validates(self) -> None:
+    event = self._load_example()
+
+    validate_audit_event(event)
+
+  def test_rejects_audit_event_that_stores_raw_prompts(self) -> None:
+    event = self._load_example()
+    event["redaction"]["raw_prompts_stored"] = True
+
+    with self.assertRaisesRegex(ValueError, "raw_prompts_stored"):
+      validate_audit_event(event)
+
+  def test_rejects_unknown_policy_status(self) -> None:
+    event = self._load_example()
+    event["policy_checks"][0]["status"] = "unknown"
+
+    with self.assertRaisesRegex(ValueError, "unsupported policy check status"):
+      validate_audit_event(event)
+
+  def _load_example(self) -> dict:
+    example_path = (
+      Path(__file__).resolve().parents[2]
+      / "examples"
+      / "governance_audit_event.json"
+    )
+    return json.loads(example_path.read_text(encoding="utf-8"))
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/CybersecurityBenchmarks/docs/governance_audit_trails.md
+++ b/CybersecurityBenchmarks/docs/governance_audit_trails.md
@@ -1,0 +1,36 @@
+# Governance audit trails for CyberSecEval runs
+
+CyberSecEval runs can produce security findings that enterprise teams need to
+review, track, and remediate over time. This document defines a small,
+vendor-neutral audit event that can sit next to benchmark output files without
+claiming legal or regulatory compliance certification.
+
+The event records:
+
+- which benchmark ran
+- which model and dataset were evaluated
+- where the stat and judge response artifacts were written
+- which policy checks ran before accepting the result
+- whether human review or remediation is required
+- which fields were redacted before persistent audit storage
+
+See [`../examples/governance_audit_event.json`](../examples/governance_audit_event.json)
+for a complete example.
+
+## Redaction boundary
+
+Audit records should not store raw prompts, raw model responses, secrets, API
+keys, customer data, or exploit payload text by default. Prefer hashes,
+fingerprints, output paths, aggregate counts, and remediation metadata.
+
+## Suggested decisions
+
+- `pass`: benchmark evidence is recorded and no local policy check requires
+  review.
+- `fail`: a hard policy check failed.
+- `needs_review`: the benchmark produced findings or ambiguous evidence that
+  should be routed to a human security reviewer.
+
+This audit event is an evidence and workflow aid. It does not certify that a
+model, benchmark run, deployment, or organization is compliant with any law,
+regulation, or internal policy.

--- a/CybersecurityBenchmarks/examples/governance_audit_event.json
+++ b/CybersecurityBenchmarks/examples/governance_audit_event.json
@@ -1,0 +1,61 @@
+{
+  "schema_version": "cyberseceval-governance-audit-v1",
+  "event_id": "audit_evt_20260507_001",
+  "benchmark": "prompt-injection",
+  "run": {
+    "run_id": "prompt_injection_redacted_demo",
+    "started_at": "2026-05-07T00:00:00Z",
+    "completed_at": "2026-05-07T00:03:00Z"
+  },
+  "model": {
+    "provider": "example-provider",
+    "name": "example-model"
+  },
+  "dataset": {
+    "path": "CybersecurityBenchmarks/datasets/prompt_injection/prompt_injection.json",
+    "fingerprint": "sha256:example-dataset-fingerprint"
+  },
+  "result": {
+    "decision": "needs_review",
+    "total_count": 100,
+    "finding_count": 7,
+    "stat_path": "CybersecurityBenchmarks/datasets/results/prompt_injection_stat.json",
+    "judge_response_path": "CybersecurityBenchmarks/datasets/results/prompt_injection_judge_responses.json"
+  },
+  "policy_checks": [
+    {
+      "check_id": "result_paths_recorded",
+      "status": "pass",
+      "evidence": "stat_path and judge_response_path are captured for review."
+    },
+    {
+      "check_id": "threshold_review",
+      "status": "needs_review",
+      "evidence": "finding_count is above the local enterprise review threshold."
+    },
+    {
+      "check_id": "raw_prompt_redaction",
+      "status": "pass",
+      "evidence": "Only dataset and output fingerprints are retained in the audit record."
+    }
+  ],
+  "remediation": {
+    "status": "open",
+    "owner": "security-review",
+    "ticket": "SEC-REVIEW-001"
+  },
+  "redaction": {
+    "raw_prompts_stored": false,
+    "raw_responses_stored": false,
+    "stored_fields": [
+      "benchmark",
+      "run_id",
+      "model",
+      "dataset.fingerprint",
+      "result.stat_path",
+      "result.judge_response_path",
+      "policy_checks",
+      "remediation.status"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a dependency-free CyberSecEval governance audit event validator
- add a redacted example audit event for benchmark run evidence, policy checks, and remediation tracking
- document the audit trail boundary and add unittest coverage for valid and unsafe audit records

## Tests
- `python -m json.tool CybersecurityBenchmarks\examples\governance_audit_event.json`
- `python -m unittest benchmark.tests.test_audit_trail` from `CybersecurityBenchmarks/`
- `python -m unittest discover benchmark.tests` from `CybersecurityBenchmarks/`
- `python -m py_compile CybersecurityBenchmarks\benchmark\audit_trail.py CybersecurityBenchmarks\benchmark\tests\test_audit_trail.py`

Closes #190.