### PR TITLE
Fix static model warning for custom endpoints

### DIFF
--- a/CybersecurityBenchmarks/benchmark/llms/llm_base.py
+++ b/CybersecurityBenchmarks/benchmark/llms/llm_base.py
@@ -58,7 +58,7 @@ class LLM(ABC):
         self.max_tokens: int = config.max_tokens
         self.cot_end_tokens: list[str] | None = config.cot_end_tokens
         self.base_url: str | None = config.base_url
-        if self.model not in self.valid_models():
+        if self.base_url is None and self.model not in self.valid_models():
             LOG.warning(
                 f"{self.model} is not in the valid model list for {type(self).__name__}. Valid models are: {', '.join(self.valid_models())}."
             )

--- a/CybersecurityBenchmarks/benchmark/tests/test_llm.py
+++ b/CybersecurityBenchmarks/benchmark/tests/test_llm.py
@@ -86,3 +86,33 @@ class TestLLM(unittest.TestCase):
         # When base_url is None, OpenAI client should use default endpoint
         # The default OpenAI base_url is "https://api.openai.com/v1"
         self.assertEqual(str(openai_llm.client.base_url), "https://api.openai.com/v1/")
+
+    def test_custom_endpoint_skips_static_model_warning(self) -> None:
+        custom_config = LLMConfig(
+            model="qwen3:4b-instruct",
+            api_key="ollama",
+            base_url="http://localhost:11434/v1/",
+        )
+
+        with self.assertNoLogs(
+            "CybersecurityBenchmarks.benchmark.llms.llm_base",
+            level="WARNING",
+        ):
+            OPENAI(custom_config)
+
+        default_config = LLMConfig(
+            model="unknown-model",
+            api_key="test-api-key",
+        )
+
+        with self.assertLogs(
+            "CybersecurityBenchmarks.benchmark.llms.llm_base",
+            level="WARNING",
+        ) as logs:
+            OPENAI(default_config)
+
+        self.assertIn(
+            "unknown-model is not in the valid model list",
+            logs.output[0],
+        )
+


### PR DESCRIPTION
## Summary
- Skip the static model-list warning when an explicit custom `base_url` is supplied.
- Add regression coverage for custom-endpoint and default-endpoint behavior.

## Motivation
OpenAI-compatible custom endpoints can expose arbitrary model names. Previously, valid local models such as Ollama-hosted Qwen emitted an unsupported-model warning even though requests succeeded.

## Testing
- `python -m unittest CybersecurityBenchmarks.benchmark.tests.test_llm`
- Local Ollama smoke test using `qwen3:4b-instruct` through its OpenAI-compatible endpoint.
