### PR TITLE
Add NOVITA provider for CybersecurityBenchmarks

### DIFF
--- a/CybersecurityBenchmarks/README.md
+++ b/CybersecurityBenchmarks/README.md
@@ -127,7 +127,7 @@ The followings are a few examples:
 - `OPENAI::gpt-3.5-turbo::<API KEY>`
 - `OPENAI::gpt-3.5-turbo::<API KEY>::https://api.openai.com/v1/`
 - `TOGETHER::togethercomputer/llama-2-7b::<API KEY>`
-- `NOVITA::meta-llama/llama-3.3-70b-instruct::<API KEY>`
+- `NOVITA::moonshotai/kimi-k3::<API KEY>`
 
 ### How to run benchmarks for additional models and inference APIs
 

--- a/CybersecurityBenchmarks/README.md
+++ b/CybersecurityBenchmarks/README.md
@@ -119,7 +119,7 @@ export DATASETS=$PWD/CybersecurityBenchmarks/datasets
 
 Each benchmark can run tests for multiple LLMs. Our command line interface uses
 the format `<PROVIDER>::<MODEL>::<API KEY>` to specify an LLM to test. We
-currently support APIs from OPENAI, GOOGLE, ANTHROPIC, LLAMA and TOGETHER. For OpenAI compatible endpoints,
+currently support APIs from OPENAI, GOOGLE, ANTHROPIC, LLAMA, TOGETHER and NOVITA. For OpenAI compatible endpoints,
 you can also specify a custom base URL by using this format: `<PROVIDER>::<MODEL>::<API KEY>::<BASE URL>`.
 The followings are a few examples:
 
@@ -127,6 +127,7 @@ The followings are a few examples:
 - `OPENAI::gpt-3.5-turbo::<API KEY>`
 - `OPENAI::gpt-3.5-turbo::<API KEY>::https://api.openai.com/v1/`
 - `TOGETHER::togethercomputer/llama-2-7b::<API KEY>`
+- `NOVITA::meta-llama/llama-3.3-70b-instruct::<API KEY>`
 
 ### How to run benchmarks for additional models and inference APIs
 

--- a/CybersecurityBenchmarks/benchmark/llm.py
+++ b/CybersecurityBenchmarks/benchmark/llm.py
@@ -24,6 +24,7 @@ from .llms.llm_base import (
     UnretriableQueryException,
 )
 from .llms.meta import LLAMA
+from .llms.novita import NOVITA
 from .llms.openai import OPENAI
 from .llms.together import TOGETHER
 
@@ -80,6 +81,8 @@ def create(
         return OPENAI(config)
     if provider == "TOGETHER":
         return TOGETHER(config)
+    if provider == "NOVITA":
+        return NOVITA(config)
     if provider == "ANTHROPIC":
         return ANTHROPIC(config)
     if provider == "GOOGLEGENAI":

--- a/CybersecurityBenchmarks/benchmark/llms/novita.py
+++ b/CybersecurityBenchmarks/benchmark/llms/novita.py
@@ -211,6 +211,7 @@ class NOVITA(LLM):
     @override
     def valid_models(self) -> list[str]:
         return [
-            "meta-llama/llama-3.3-70b-instruct",
-            "deepseek/deepseek-r1",
+            "moonshotai/kimi-k3",
+            "zai-org/glm-5.2",
+            "deepseek/deepseek-v4-flash-0731",
         ]

--- a/CybersecurityBenchmarks/benchmark/llms/novita.py
+++ b/CybersecurityBenchmarks/benchmark/llms/novita.py
@@ -1,0 +1,216 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import openai
+from typing_extensions import override
+
+from ..benchmark_utils import image_to_b64
+from .llm_base import (
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_TOP_P,
+    LLM,
+    LLMConfig,
+    UnretriableQueryException,
+)
+
+
+class NOVITA(LLM):
+    """Accessing NOVITA"""
+
+    def __init__(self, config: LLMConfig) -> None:
+        super().__init__(config)
+
+        self.client = openai.OpenAI(
+            api_key=self.api_key,
+            base_url="https://api.novita.ai/openai",
+        )
+
+    @override
+    def chat(
+        self,
+        prompt_with_history: List[str],
+        guided_decode_json_schema: Optional[str] = None,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+    ) -> str:
+        messages = []
+        for i in range(len(prompt_with_history)):
+            if i % 2 == 0:
+                messages.append({"role": "user", "content": prompt_with_history[i]})
+            else:
+                messages.append(
+                    {"role": "assistant", "content": prompt_with_history[i]}
+                )
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            top_p=top_p,
+            response_format=(
+                {"type": "json_object"}
+                if guided_decode_json_schema is not None
+                else None
+            ),
+        )
+        # pyrefly: ignore [missing-attribute]
+        return response.choices[0].message.content
+
+    @override
+    def chat_with_system_prompt(
+        self,
+        system_prompt: str,
+        prompt_with_history: List[str],
+        guided_decode_json_schema: Optional[str] = None,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+    ) -> str:
+        messages = [{"role": "system", "content": system_prompt}]
+        for i in range(len(prompt_with_history)):
+            if i % 2 == 0:
+                messages.append({"role": "user", "content": prompt_with_history[i]})
+            else:
+                messages.append(
+                    {"role": "assistant", "content": prompt_with_history[i]}
+                )
+
+        level = logging.getLogger().level
+        logging.getLogger().setLevel(logging.WARNING)
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            top_p=top_p,
+            response_format=(
+                {"type": "json_object"}
+                if guided_decode_json_schema is not None
+                else None
+            ),
+        )
+        logging.getLogger().setLevel(level)
+        # pyrefly: ignore [missing-attribute]
+        return response.choices[0].message.content
+
+    @override
+    def query(
+        self,
+        prompt: str,
+        guided_decode_json_schema: Optional[str] = None,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+    ) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            top_p=top_p,
+            response_format=(
+                {"type": "json_object"}
+                if guided_decode_json_schema is not None
+                else None
+            ),
+        )
+        # pyrefly: ignore [missing-attribute]
+        return response.choices[0].message.content
+
+    @override
+    def query_with_system_prompt(
+        self,
+        system_prompt: str,
+        prompt: str,
+        guided_decode_json_schema: Optional[str] = None,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+    ) -> str:
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=temperature,
+            top_p=top_p,
+            response_format=(
+                {"type": "json_object"}
+                if guided_decode_json_schema is not None
+                else None
+            ),
+        )
+        # pyrefly: ignore [missing-attribute]
+        return response.choices[0].message.content
+
+    @override
+    def query_multimodal(
+        self,
+        system_prompt: Optional[str] = None,
+        text_prompt: Optional[str] = None,
+        image_paths: Optional[List[str]] = None,
+        audio_paths: Optional[List[str]] = None,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        temperature: float = DEFAULT_TEMPERATURE,
+        top_p: float = DEFAULT_TOP_P,
+    ) -> str:
+        # Novita's OpenAI-compatible chat API supports images but not audio.
+        if audio_paths and len(audio_paths) > 0:
+            raise UnretriableQueryException(
+                "NOVITA chat-completions does not support audio inputs yet."
+            )
+
+        if text_prompt is None and (image_paths is None or len(image_paths) == 0):
+            raise ValueError(
+                "At least one of text_prompt or image_paths must be given."
+            )
+
+        messages = []
+        if system_prompt:
+            messages.append({"role": "system", "content": system_prompt})
+
+        user_content: list[dict[str, str | dict[str, str]]] = []
+        if text_prompt:
+            user_content.append({"type": "text", "text": text_prompt})
+
+        if image_paths and len(image_paths) > 0:
+            for image_path in image_paths:
+                image_data = image_to_b64(image_path)
+                user_content.append(
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:image/png;base64,{image_data}"},
+                    }
+                )
+
+        # pyrefly: ignore [bad-argument-type, bad-assignment]
+        messages.append({"role": "user", "content": user_content})
+
+        response = self.client.chat.completions.create(
+            model=self.model,
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            top_p=top_p,
+        )
+        # pyrefly: ignore [missing-attribute]
+        return response.choices[0].message.content
+
+    @override
+    def valid_models(self) -> list[str]:
+        return [
+            "meta-llama/llama-3.3-70b-instruct",
+            "deepseek/deepseek-r1",
+        ]

--- a/CybersecurityBenchmarks/benchmark/tests/test_llm.py
+++ b/CybersecurityBenchmarks/benchmark/tests/test_llm.py
@@ -24,10 +24,10 @@ class TestLLM(unittest.TestCase):
 
     def test_create_novita(self) -> None:
         novita = llm.create(
-            "NOVITA::meta-llama/llama-3.3-70b-instruct::<my API key>"
+            "NOVITA::moonshotai/kimi-k3::<my API key>"
         )
         self.assertTrue(isinstance(novita, llm.NOVITA))
-        self.assertEqual(novita.model, "meta-llama/llama-3.3-70b-instruct")
+        self.assertEqual(novita.model, "moonshotai/kimi-k3")
         self.assertEqual(novita.api_key, "<my API key>")
         self.assertEqual(str(novita.client.base_url), "https://api.novita.ai/openai/")
 

--- a/CybersecurityBenchmarks/benchmark/tests/test_llm.py
+++ b/CybersecurityBenchmarks/benchmark/tests/test_llm.py
@@ -22,6 +22,15 @@ class TestLLM(unittest.TestCase):
 
         self.assertRaises(ValueError, lambda: llm.create("GPT::unknown::<my API key"))
 
+    def test_create_novita(self) -> None:
+        novita = llm.create(
+            "NOVITA::meta-llama/llama-3.3-70b-instruct::<my API key>"
+        )
+        self.assertTrue(isinstance(novita, llm.NOVITA))
+        self.assertEqual(novita.model, "meta-llama/llama-3.3-70b-instruct")
+        self.assertEqual(novita.api_key, "<my API key>")
+        self.assertEqual(str(novita.client.base_url), "https://api.novita.ai/openai/")
+
     def test_create_with_base_url(self) -> None:
         """Test that create() function works with base_url parameter."""
         # Test 4-part format: PROVIDER::MODEL::API_KEY::BASE_URL


### PR DESCRIPTION

## Summary

Adds a `NOVITA` provider to the CybersecurityBenchmarks LLM registry, following the existing `TOGETHER` provider's structure (an OpenAI-compatible client with a fixed `base_url`).

## Changes

- `CybersecurityBenchmarks/benchmark/llms/novita.py`: new `NOVITA` provider class implementing `chat`, `chat_with_system_prompt`, `query`, `query_with_system_prompt`, and `query_multimodal`, pointed at `https://api.novita.ai/openai`.
- `CybersecurityBenchmarks/benchmark/llm.py`: import and register `NOVITA` in `create()`.
- `CybersecurityBenchmarks/README.md`: add `NOVITA` to the supported provider list and an example invocation.
- `CybersecurityBenchmarks/benchmark/tests/test_llm.py`: add `test_create_novita`, mirroring the existing `TOGETHER` coverage.

## Verification

- `python3 -m unittest discover benchmark.tests` (venv with `CybersecurityBenchmarks/requirements.txt`): 8 passed (7 baseline + 1 new `test_create_novita`), no regressions.
- `NOVITA::deepseek/deepseek-v4-flash-0731::<API key>` via `benchmark.llm.create(...).query(...)` returned a non-empty response against the live Novita API.
