### PR TITLE
docs: add AgentThreatBench as a complementary CyberSecEval reference

### DIFF
--- a/CybersecurityBenchmarks/README.md
+++ b/CybersecurityBenchmarks/README.md
@@ -77,6 +77,36 @@ The repository includes several types of benchmarks:
 Please take a look at our [wiki](https://meta-llama.github.io/PurpleLlama/)
 which contains detailed instructions on how to execute our benchmarks.
 
+## Related complementary evaluations
+
+CyberSecEval's prompt-injection suites measure whether an LLM follows injected
+instructions in **user-provided** text or images. They do not currently ship
+multi-step agent evaluations where the adversarial payload is embedded in
+**tool outputs or memory stores**.
+
+[AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/)
+is a complementary evaluation in the UK AI Safety Institute's
+[`inspect_evals`](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/agent_threat_bench)
+suite. It operationalizes a subset of the
+[OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+as executable Inspect AI tasks. As of this writing it includes three tasks
+covering two ASI categories:
+
+| Task | Attack surface | OWASP ID |
+| --- | --- | --- |
+| Memory poison | Adversarial RAG / memory-store entries | ASI06 |
+| Autonomy hijack | Indirect injection in `read_inbox` tool output | ASI01 |
+| Data exfiltration | Indirect injection in `lookup_customer` tool output | ASI01 |
+
+AgentThreatBench scores **utility** (task completion) and **security** (attack
+resistance) independently. It is **not** vendored here and is **not** runnable
+through `CybersecurityBenchmarks.benchmark.run`. To run it, follow the
+inspect_evals documentation (`pip install inspect-evals`).
+
+This section is a documentation pointer only. A first-party CyberSecEval
+integration would be a larger change and should be discussed with maintainers
+first (see [issue #230](https://github.com/meta-llama/PurpleLlama/issues/230)).
+
 # Getting Started
 
 Note that python 3.10 is required.

--- a/CybersecurityBenchmarks/website/docs/benchmarks/prompt_injection.md
+++ b/CybersecurityBenchmarks/website/docs/benchmarks/prompt_injection.md
@@ -185,3 +185,14 @@ The result of each bucket follows the same structure.
     }
 }
 ```
+
+## Related complementary evaluation
+
+CyberSecEval prompt-injection tests primarily inject instructions through
+**user text or images**. For multi-step **agent** scenarios where the payload
+is embedded in tool outputs or memory (a subset of the
+[OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)),
+see [AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/)
+in UK AISI [`inspect_evals`](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/agent_threat_bench).
+That suite is complementary and is not executed by
+`CybersecurityBenchmarks.benchmark.run`.

--- a/CybersecurityBenchmarks/website/docs/intro.md
+++ b/CybersecurityBenchmarks/website/docs/intro.md
@@ -73,3 +73,22 @@ The repository includes several types of benchmarks:
 9.  **CyberSOCEval Tests**: These tests, created in partnership with Crowdstrike, assess defensive capabilities and include two benchmarks:
     * Malware Analysis:  Assesses the precision and recall of LLMs in identifying malicious activities from potential malware, such as detecting ransomware or remote access trojans via mutiple choice questions where multple options may be correct.
     * Threat Intelligence Reasoning: Evaluates an AI's ability to parse unstructured threat intelligence reports and extract actionable insights via mutiple choice questions where multple options may be correct.
+
+## Related complementary evaluations
+
+CyberSecEval's prompt-injection suites measure whether an LLM follows injected
+instructions in **user-provided** text or images. They do not currently ship
+multi-step agent evaluations where the adversarial payload is embedded in
+**tool outputs or memory stores**.
+
+[AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/)
+is a complementary evaluation in the UK AI Safety Institute's
+[`inspect_evals`](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/agent_threat_bench)
+suite. It operationalizes a subset of the
+[OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/)
+as executable Inspect AI tasks. As of this writing it includes three tasks
+covering two ASI categories (ASI01 Agent Goal Hijack and ASI06 Memory & Context
+Poisoning). It scores utility and security independently and is **not**
+included in this repository. See the
+[CybersecurityBenchmarks README](https://github.com/meta-llama/PurpleLlama/blob/main/CybersecurityBenchmarks/README.md#related-complementary-evaluations)
+for links and a short comparison.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ You can also check out the 🤗 leaderboard [here](https://huggingface.co/spaces
 #### CyberSec Eval 3
 The newly released CyberSec Eval 3 features three additional test suites: visual prompt injection tests, spear phishing capability tests, and autonomous offensive cyber operations tests.
 
+#### Related complementary evaluations
+For multi-step **agentic** attacks — where adversarial payloads sit in tool outputs or memory, aligned to a subset of the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/) — see [AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/) in the UK AI Safety Institute [`inspect_evals`](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/agent_threat_bench) suite. It is complementary to CyberSecEval and is not included in this repository. Details are in the [CybersecurityBenchmarks README](CybersecurityBenchmarks/README.md#related-complementary-evaluations).
+
 ## Getting Started
 
 As part of the [Llama reference system](https://github.com/meta-llama/llama-agentic-system), we’re integrating a safety layer to facilitate adoption and deployment of these safeguards.


### PR DESCRIPTION
## Summary
- Adds a documentation pointer to [AgentThreatBench](https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/agent_threat_bench/) as a complementary evaluation for multi-step agentic attacks (payloads in tool outputs or memory), aligned to a subset of the [OWASP Top 10 for Agentic Applications (2026)](https://genai.owasp.org/resource/owasp-top-10-for-agentic-applications-for-2026/).
- Updates the root README, CybersecurityBenchmarks/README.md, and the CyberSecEval website intro / prompt-injection pages.
- Does **not** vendor the benchmark, add a runner, or claim in-repo execution. Coverage is stated accurately: three inspect_evals tasks covering ASI01 and ASI06, not the full OWASP Agentic Top 10.

Related to #230.

## Test plan
- [ ] Confirm the new section in CybersecurityBenchmarks/README.md is clearly separate from the in-repo benchmark list.
- [ ] Click through the three external links (inspect_evals docs, source tree, OWASP Agentic Top 10).
- [ ] Confirm the website intro and prompt-injection pages match the README wording (complementary, not integrated).
- [ ] Confirm no Python / benchmark code paths changed.

I will sign the Meta CLA if the bot asks.
