### PR TITLE
fix: support Hugging Face Hub v1 authentication APIs

### DIFF
--- a/LlamaFirewall/README.md
+++ b/LlamaFirewall/README.md
@@ -161,7 +161,7 @@ If you prefer to set up manually:
 1. Preload the Model: Preload the model to your local cache directory, `~/.cache/huggingface`.
 2. Alternative Option: Make sure your HF account has been set up, and for any missing model, LlamaFirewall will automate the download. To verify your HF login, try:
    ```bash
-   huggingface-cli whoami
+   hf auth whoami
    ```
    If you are not logged in, then you can log in via:
    ```bash

--- a/LlamaFirewall/src/llamafirewall/cli/configure.py
+++ b/LlamaFirewall/src/llamafirewall/cli/configure.py
@@ -15,8 +15,7 @@ with the necessary tokens and API keys.
 import os
 
 import typer
-from huggingface_hub import HfFolder, login
-
+from huggingface_hub import get_token, login
 # Default model name for PromptGuard
 DEFAULT_MODEL_NAME = "meta-llama/Llama-Prompt-Guard-2-86M"
 
@@ -93,7 +92,7 @@ def download_model(model_name: str = DEFAULT_MODEL_NAME) -> bool:
         )
 
         # Check if the user is logged in to Hugging Face
-        if not HfFolder.get_token():
+        if not get_token():
             print("You need to log in to Hugging Face to download the model.")
             login()
 

--- a/LlamaFirewall/tests/test_configure.py
+++ b/LlamaFirewall/tests/test_configure.py
@@ -1,0 +1,71 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from llamafirewall.cli.configure import download_model
+
+
+class TestConfigureModelDownload(unittest.TestCase):
+    @patch("llamafirewall.cli.configure.login")
+    @patch(
+        "llamafirewall.cli.configure.get_token",
+        return_value="existing-huggingface-token",
+    )
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForSequenceClassification.from_pretrained")
+    @patch.dict(os.environ, {"HF_HOME": "test-hf-home"})
+    def test_download_model_uses_existing_huggingface_token(
+        self,
+        mock_model_from_pretrained: MagicMock,
+        mock_tokenizer_from_pretrained: MagicMock,
+        mock_get_token: MagicMock,
+        mock_login: MagicMock,
+    ) -> None:
+        model_name = "meta-llama/test-model"
+
+        result = download_model(model_name)
+
+        self.assertTrue(result)
+        mock_get_token.assert_called_once_with()
+        mock_login.assert_not_called()
+        mock_model_from_pretrained.assert_called_once_with(model_name)
+        mock_tokenizer_from_pretrained.assert_called_once_with(
+            model_name,
+            fix_mistral_regex=True,
+        )
+
+    @patch("llamafirewall.cli.configure.login")
+    @patch("llamafirewall.cli.configure.get_token", return_value=None)
+    @patch("transformers.AutoTokenizer.from_pretrained")
+    @patch("transformers.AutoModelForSequenceClassification.from_pretrained")
+    @patch.dict(os.environ, {"HF_HOME": "test-hf-home"})
+    def test_download_model_logs_in_when_token_is_missing(
+        self,
+        mock_model_from_pretrained: MagicMock,
+        mock_tokenizer_from_pretrained: MagicMock,
+        mock_get_token: MagicMock,
+        mock_login: MagicMock,
+    ) -> None:
+        model_name = "meta-llama/test-model"
+
+        result = download_model(model_name)
+
+        self.assertTrue(result)
+        mock_get_token.assert_called_once_with()
+        mock_login.assert_called_once_with()
+        mock_model_from_pretrained.assert_called_once_with(model_name)
+        mock_tokenizer_from_pretrained.assert_called_once_with(
+            model_name,
+            fix_mistral_regex=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fix LlamaFirewall compatibility with huggingface_hub v1 by replacing the
removed HfFolder API with get_token().

- Replace HfFolder.get_token() with huggingface_hub.get_token().
- Update authentication instructions to use the current hf CLI.
- Add regression tests for existing and missing authentication tokens.

Fixes #219.

## Testing

python -m py_compile LlamaFirewall/src/llamafirewall/cli/configure.py LlamaFirewall/tests/test_configure.py

python -m unittest discover -s LlamaFirewall/tests -p test_configure.py -v

Result: 2 tests passed.